### PR TITLE
fix: update Netlify publish dir and cache headers

### DIFF
--- a/infrastructure/ci/netlify.toml
+++ b/infrastructure/ci/netlify.toml
@@ -4,7 +4,7 @@
 [build]
   # Skip all build commands - files are pre-built by GitHub Actions
   command = "echo 'Build completed in GitHub Actions - serving pre-built files'"
-  publish = "dist"
+  publish = "workspace/build"
   ignore = "exit 0"  # Always skip builds
 
 [build.environment]
@@ -14,17 +14,17 @@
 # Force skip builds for all contexts
 [context.production]
   command = "echo 'Production build completed in GitHub Actions - serving pre-built files'"
-  publish = "dist"
+  publish = "workspace/build"
 
 [context.deploy-preview]
   command = "echo 'Deploy preview build completed in GitHub Actions - serving pre-built files'"
-  publish = "dist"
+  publish = "workspace/build"
 
 [context.branch-deploy]
   command = "echo 'Branch deploy build completed in GitHub Actions - serving pre-built files'"
-  publish = "dist"
+  publish = "workspace/build"
 
-# Headers for optimal performance
+# Headers for optimal performance and cache invalidation
 [[headers]]
   for = "/*"
   [headers.values]
@@ -32,6 +32,7 @@
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=()"
+    Cache-Control = "public, max-age=0, must-revalidate"
 
 # Cache static assets aggressively
 [[headers]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,22 @@
+[build]
+  # Disable Netlify builds - we build in GitHub Actions
+  command = "echo 'Build disabled - serving from GitHub Actions artifacts only'"
+  publish = "workspace/build"
+  ignore = "git diff --quiet HEAD^ HEAD"
+
+# Force cache invalidation
+[build.environment]
+  NETLIFY_SKIP_FUNCTIONS_CACHE = "true"
+
+# Headers to prevent caching issues
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Cache-Control = "public, max-age=0, must-revalidate"
+
+[[headers]]
+  for = "/api/*"
+  [headers.values]
+    Cache-Control = "no-cache, no-store, must-revalidate"
+    Pragma = "no-cache"
+    Expires = "0"


### PR DESCRIPTION
## Problem

The Training section was missing from the staging deployment despite successful GitHub Actions builds because:

1. **Netlify publish directory mismatch**: Netlify was configured to serve from `dist/` but GitHub Actions builds to `workspace/build/`
2. **Cache invalidation issues**: No cache-control headers to force content refresh

## Solution

- ✅ **Fixed publish directory**: Changed from `dist` to `workspace/build` in all contexts
- ✅ **Added cache invalidation**: Added `Cache-Control: public, max-age=0, must-revalidate` headers
- ✅ **Maintained security headers**: Kept existing security configuration

## Testing

This should fix the staging deployment issue where new content wasn't appearing due to:
- Wrong directory being served by Netlify
- Aggressive caching preventing content updates

Deployment will be tested once merged to main.