### PR TITLE
fix: exempt Release Please PRs from divergence check

### DIFF
--- a/.github/workflows/divergence-check.yml
+++ b/.github/workflows/divergence-check.yml
@@ -12,6 +12,8 @@ jobs:
   divergence-check:
     name: 🔍 Divergence Check
     runs-on: ubuntu-latest
+    # Skip divergence check for Release Please PRs as they are expected to diverge
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -53,3 +55,20 @@ jobs:
             echo "✅ Branch is up-to-date with ${{ github.base_ref }}"
             echo "💡 No new commits to merge"
           fi
+
+  release-please-check:
+    name: 🔍 Release Please - Divergence Allowed
+    runs-on: ubuntu-latest
+    # Only run for Release Please PRs
+    if: ${{ startsWith(github.head_ref, 'release-please--') }}
+    steps:
+      - name: Release Please PR - Skip Divergence Check
+        run: |
+          echo "🚀 RELEASE PLEASE PR DETECTED"
+          echo "=============================="
+          echo ""
+          echo "✅ This is a Release Please PR - divergence is expected and allowed"
+          echo "📋 Release Please PRs contain new version commits and CHANGELOG updates"
+          echo "🔄 No branch update required - ready for manual review and merge"
+          echo ""
+          echo "💡 Action: Review the release notes and merge when ready to release"


### PR DESCRIPTION
## Summary
Fixes the divergence check for Release Please PRs by exempting them from the check since they are expected to diverge.

## Problem
Release Please PRs were failing divergence checks because they intentionally contain new version commits and CHANGELOG updates that make them diverge from main.

## Solution
- Skip regular divergence check for Release Please PRs (branches starting with `release-please--`)
- Add dedicated job that passes for Release Please PRs with informative message
- This allows Release Please PRs to pass checks while maintaining divergence protection for regular PRs

## Testing
- Targets PR #110 which is currently blocked by divergence check
- Will allow Release Please workflow to function correctly