### PR TITLE
🔧 Fix Staging Environment Detection

### DIFF
--- a/app/pages/api/version.ts
+++ b/app/pages/api/version.ts
@@ -102,7 +102,7 @@ function getEnvironmentInfo() {
     environmentType = 'production';
     environmentName = 'GitHub Pages';
   } else if (process.env.NETLIFY === 'true') {
-    if (process.env.CONTEXT === 'production') {
+    if (process.env.CONTEXT === 'production' || process.env.CONTEXT === 'staging') {
       environmentType = 'staging';
       environmentName = 'Netlify Staging';
     } else if (process.env.CONTEXT === 'deploy-preview') {


### PR DESCRIPTION
## 🔧 Fix Staging Environment Detection

Fixes staging environment classification to show correct `environmentType: "staging"`.

### 🐛 Issue
Currently staging shows:
```json
{
  "environmentType": "development",  // ❌ Wrong
  "context": "staging" 
}
```

### ✅ Solution  
Add `CONTEXT === 'staging'` detection alongside `CONTEXT === 'production'`:

```typescript
if (process.env.CONTEXT === 'production' || process.env.CONTEXT === 'staging') {
  environmentType = 'staging';
  environmentName = 'Netlify Staging';
}
```

### 🎯 Expected Result
After this fix, staging will show:
```json
{
  "environmentType": "staging",     // ✅ Correct  
  "semanticVersion": "v4.16.0+4",  // ✅ With build metadata
  "context": "staging"
}
```

### 🧪 Testing  
- Deploy to staging → Check `/api/version` endpoint
- Verify `environmentType: "staging"` 
- Confirm semantic version shows build metadata format

---

**🚀 Completes semantic versioning implementation!**