### PR TITLE
ci: redirect GitHub Pages to CF worker domain

### DIFF
--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -1,15 +1,20 @@
 ---
-name: 🚀 Production Deployment
+name: 🔀 Legacy Pages Redirect
+
+# Production moved to the Cloudflare Worker at resume.rafaracing.com.br
+# (Workers Static Assets — the site AND the AI on one domain). GitHub Pages now
+# serves a permanent client-side redirect there, so old bookmarks/links keep
+# working and SEO consolidates on the new domain. (GitHub Pages can't issue a
+# real 301, so this uses canonical + meta-refresh + JS, and a 404.html that
+# catches every deep path.)
 
 on:
-  # 🚀 Production deployment triggers
   push:
-    tags:
-      - 'v*.*.*'  # Trigger ONLY on semver tags (v1.2.3) created by release-please
-  workflow_dispatch:  # Allow manual triggering from GitHub UI
+    branches: [main]
+  workflow_dispatch:
 
 concurrency:
-  group: production-deploy-${{ github.ref }}
+  group: pages-redirect
   cancel-in-progress: true
 
 permissions:
@@ -18,205 +23,74 @@ permissions:
   id-token: write
 
 jobs:
-  build:
-    name: 🏗️ Build Production Resume
-    uses: ./.github/workflows/shared-build.yml
-    with:
-      build-context: 'production'
-      deploy-url: 'https://rafilkmp3.github.io/resume-as-code'
-      cache-key-suffix: 'production-arm64'
-
-  deploy:
-    name: 🚀 Deploy to GitHub Pages
-    needs: build
+  redirect:
+    name: 🔀 Deploy redirect to GitHub Pages
     runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    permissions:
-      pages: write
-      id-token: write
-    
+      url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - name: 📂 Checkout Repository
-        uses: actions/checkout@v4
-      
-      - name: 📥 Download Build Artifacts
-        uses: ./.github/actions/manage-artifacts
-        with:
-          action: 'download'
-          build-context: 'production'
-
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-        
-      - name: 🧹 Clear GitHub Pages Cache (Force Rebuild)
+      - name: Generate redirect site
         run: |
-          echo "🧹 Forcing GitHub Pages cache invalidation..."
-          # Create unique timestamp file to force GitHub Pages rebuild
-          echo "Build timestamp: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" > ./workspace/build/.rebuild-timestamp
-          echo "Build hash: ${{ github.sha }}" >> ./workspace/build/.rebuild-timestamp
-          echo "✅ Cache invalidation marker created"
+          set -euo pipefail
+          TARGET="https://resume.rafaracing.com.br"
+          mkdir -p _site
+          cat > _site/index.html <<HTML
+          <!doctype html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>Rafael Bernardo Sathler — Resume</title>
+            <link rel="canonical" href="${TARGET}/">
+            <meta name="robots" content="noindex, follow">
+            <meta http-equiv="refresh" content="0; url=${TARGET}/">
+            <script>
+              // Strip the old /resume-as-code base path so deep links map 1:1
+              // onto the new domain, then redirect.
+              (function () {
+                var p = location.pathname.replace(/^\/resume-as-code/, '');
+                location.replace('${TARGET}' + p + location.search + location.hash);
+              })();
+            </script>
+            <style>
+              html { color-scheme: dark; }
+              body {
+                margin: 0; min-height: 100vh; display: grid; place-items: center;
+                background: #0b0f14; color: #e6e8eb; text-align: center;
+                font: 500 1rem/1.5 -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+              }
+              a { color: #6ea8fe; }
+            </style>
+          </head>
+          <body>
+            <p>This resume now lives at<br><a href="${TARGET}/">resume.rafaracing.com.br</a> — redirecting…</p>
+          </body>
+          </html>
+          HTML
+          # 404.html catches every path under the project site and redirects too.
+          cp _site/index.html _site/404.html
+          echo "Generated redirect site:" && ls -la _site
 
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          path: './workspace/build'
-          
+          path: _site
+
       - name: Deploy to GitHub Pages
-        id: deployment
+        id: deploy
         uses: actions/deploy-pages@v4
 
-      - name: 🔍 Post-Deployment Health Check & Verification
-        if: steps.deployment.outcome == 'success'
-        timeout-minutes: 5
+      - name: Verify redirect is live
         run: |
-          echo "🔍 Starting comprehensive post-deployment health checks..."
-          
-          SITE_URL="${{ steps.deployment.outputs.page_url }}"
-          echo "🌐 Testing: ${SITE_URL}"
-          
-          # Health check tracking
-          HEALTH_CHECKS_PASSED=0
-          TOTAL_HEALTH_CHECKS=6
-          FAILED_CHECKS=""
-          
-          # Function to perform HTTP check with retry
-          check_url() {
-            local url="$1"
-            local description="$2"
-            local max_attempts=3
-            local attempt=1
-            
-            echo "🔍 Checking: ${description}"
-            
-            while [ $attempt -le $max_attempts ]; do
-              if curl -s -f -w "HTTP %{http_code} | Size: %{size_download}b | Time: %{time_total}s\n" \
-                   -H "User-Agent: GitHub-Actions-Health-Check/1.0" \
-                   -H "Cache-Control: no-cache" \
-                   "$url" > /dev/null; then
-                echo "  ✅ ${description} - Attempt ${attempt}/${max_attempts} - SUCCESS"
-                HEALTH_CHECKS_PASSED=$((HEALTH_CHECKS_PASSED + 1))
-                return 0
-              else
-                echo "  ❌ ${description} - Attempt ${attempt}/${max_attempts} - FAILED"
-                sleep $((attempt * 2))  # Exponential backoff
-                attempt=$((attempt + 1))
-              fi
-            done
-            
-            FAILED_CHECKS="${FAILED_CHECKS}\n- ${description}"
-            return 1
-          }
-          
-          # Core Health Checks
-          echo ""
-          echo "🏥 Running Core Health Checks..."
-          echo "================================="
-          
-          # 1. Main site availability
-          check_url "${SITE_URL}" "Main Site (HTML)"
-          
-          # 2. PDF-optimized HTML Pages (client generates PDFs from these)
-          check_url "${SITE_URL}pdf-screen/" "PDF Screen HTML Page"
-          check_url "${SITE_URL}pdf-print/" "PDF Print HTML Page" 
-          check_url "${SITE_URL}pdf-ats/" "PDF ATS HTML Page"
-          
-          # 3. API Endpoint (if exists)
-          check_url "${SITE_URL}api/version" "Version API Endpoint"
-          
-          # 4. Critical Assets Loading
-          check_url "${SITE_URL}assets/images/profile-optimized.jpg" "Profile Image Asset"
-          
-          # Generate health report
-          echo ""
-          echo "📊 Health Check Results:"
-          echo "======================="
-          echo "✅ Passed: ${HEALTH_CHECKS_PASSED}/${TOTAL_HEALTH_CHECKS}"
-          
-          if [ ${HEALTH_CHECKS_PASSED} -eq ${TOTAL_HEALTH_CHECKS} ]; then
-            echo "🎉 ALL HEALTH CHECKS PASSED - Production site is fully operational!"
-            echo "HEALTH_STATUS=✅ Verified" >> $GITHUB_ENV
-            echo "HEALTH_DETAILS=All ${TOTAL_HEALTH_CHECKS} health checks passed" >> $GITHUB_ENV
-          elif [ ${HEALTH_CHECKS_PASSED} -ge 4 ]; then
-            echo "⚠️ PARTIAL SUCCESS - Core functionality available but some issues detected"
-            echo "Failed checks:${FAILED_CHECKS}"
-            echo "HEALTH_STATUS=⚠️ Degraded" >> $GITHUB_ENV
-            echo "HEALTH_DETAILS=${HEALTH_CHECKS_PASSED}/${TOTAL_HEALTH_CHECKS} passed - Some non-critical issues" >> $GITHUB_ENV
-          else
-            echo "❌ CRITICAL ISSUES - Production deployment may not be fully functional"
-            echo "Failed checks:${FAILED_CHECKS}"
-            echo "HEALTH_STATUS=❌ Unhealthy" >> $GITHUB_ENV
-            echo "HEALTH_DETAILS=Only ${HEALTH_CHECKS_PASSED}/${TOTAL_HEALTH_CHECKS} passed - Critical issues detected" >> $GITHUB_ENV
-            exit 1
-          fi
-
-      - name: 📊 Production Deployment Summary
-        if: always()
-        run: |
-          # Determine deployment status dynamically
-          if [ "${{ steps.deployment.outcome }}" = "success" ]; then
-            STATUS_ICON="✅"
-            STATUS_TEXT="Production Deployment Complete"
-            if [ -n "${{ env.HEALTH_STATUS }}" ]; then
-              STATUS_TEXT="Production Deployment Complete - ${{ env.HEALTH_STATUS }}"
+          BASE="https://rafilkmp3.github.io/resume-as-code/"
+          for i in {1..12}; do
+            if curl -s -m 10 "$BASE" | grep -q "resume.rafaracing.com.br"; then
+              echo "✅ GitHub Pages now redirects to resume.rafaracing.com.br"
+              exit 0
             fi
-          elif [ "${{ steps.deployment.outcome }}" = "failure" ]; then
-            STATUS_ICON="❌"
-            STATUS_TEXT="Production Deployment Failed"
-          else
-            STATUS_ICON="⚠️"
-            STATUS_TEXT="Production Deployment ${{ steps.deployment.outcome }}"
-          fi
-          
-          # Get current timestamp and commit info
-          DEPLOY_TIME=$(TZ='America/Sao_Paulo' date '+%d/%m/%Y %H:%M:%S BRT (%Y-%m-%d %H:%M:%S UTC)')
-          COMMIT_HASH=$(echo "${{ github.sha }}" | cut -c1-7)
-          COMMIT_MSG=$(git log -1 --format=%s 2>/dev/null || echo "Release commit")
-          
-          echo "## 🚀 GitHub Pages Production Deployment" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Status**: ${STATUS_ICON} ${STATUS_TEXT}" >> $GITHUB_STEP_SUMMARY
-          echo "**Environment**: GitHub Pages (Production)" >> $GITHUB_STEP_SUMMARY
-          echo "**Release**: ${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**URL**: ${{ steps.deployment.outputs.page_url }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Deployed**: ${DEPLOY_TIME}" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit**: \`${COMMIT_HASH}\` - ${COMMIT_MSG}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 📊 Build Metrics" >> $GITHUB_STEP_SUMMARY
-          echo "- **Size**: ${{ needs.build.outputs.build-size }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Duration**: ${{ needs.build.outputs.build-duration }}s" >> $GITHUB_STEP_SUMMARY
-          echo "- **Runner**: ARM64 (40% faster than AMD64)" >> $GITHUB_STEP_SUMMARY
-          echo "- **Framework**: Astro v5.13.3" >> $GITHUB_STEP_SUMMARY
-          
-          # Add health check results if available
-          if [ -n "${{ env.HEALTH_STATUS }}" ]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### 🔍 Post-Deployment Health Check" >> $GITHUB_STEP_SUMMARY
-            echo "- **Status**: ${{ env.HEALTH_STATUS }}" >> $GITHUB_STEP_SUMMARY  
-            echo "- **Details**: ${{ env.HEALTH_DETAILS }}" >> $GITHUB_STEP_SUMMARY
-            echo "- **Verified**: Main site, PDF downloads, API endpoint, assets loading" >> $GITHUB_STEP_SUMMARY
-            echo "- **Method**: HTTP checks with retry logic and exponential backoff" >> $GITHUB_STEP_SUMMARY
-          fi
-          
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
-          if [ "${{ steps.deployment.outcome }}" = "success" ]; then
-            echo "### 🎉 Release Information" >> $GITHUB_STEP_SUMMARY
-            echo "- 🏷️ **Version**: ${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
-            echo "- 📝 **Release Notes**: [GitHub Release](${{ github.event.release.html_url }})" >> $GITHUB_STEP_SUMMARY
-            echo "- 🚀 **Deployment**: [GitHub Pages Action](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### 🔗 Production Links" >> $GITHUB_STEP_SUMMARY
-            echo "- 🌐 [Live Production Site](${{ steps.deployment.outputs.page_url }})" >> $GITHUB_STEP_SUMMARY
-            echo "- 📊 [Version API](${{ steps.deployment.outputs.page_url }}api/version)" >> $GITHUB_STEP_SUMMARY
-            echo "- 📄 [Screen PDF](${{ steps.deployment.outputs.page_url }}resume.pdf)" >> $GITHUB_STEP_SUMMARY
-            echo "- 🖨️ [Print PDF](${{ steps.deployment.outputs.page_url }}resume-print.pdf)" >> $GITHUB_STEP_SUMMARY
-            echo "- 🤖 [ATS PDF](${{ steps.deployment.outputs.page_url }}resume-ats.pdf)" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "### 🔧 Troubleshooting" >> $GITHUB_STEP_SUMMARY
-            echo "- Check [workflow logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details" >> $GITHUB_STEP_SUMMARY
-            echo "- Verify GitHub Pages configuration" >> $GITHUB_STEP_SUMMARY
-            echo "- Ensure build artifacts were created successfully" >> $GITHUB_STEP_SUMMARY
-            echo "- Check release trigger and permissions" >> $GITHUB_STEP_SUMMARY
-          fi
+            echo "⏳ Attempt $i/12: redirect not propagated yet, retrying in 10s"
+            sleep 10
+          done
+          echo "::warning::Redirect not confirmed within timeout (Pages CDN may still be propagating)"


### PR DESCRIPTION
Production moved to the Cloudflare Worker at **resume.rafaracing.com.br** (site + AI on one domain). This repurposes the old GitHub Pages production deploy to serve a permanent client-side redirect there instead of the full site — so old `rafilkmp3.github.io/resume-as-code` links keep working and SEO consolidates on the new domain.

- Canonical + meta-refresh + JS redirect; `404.html` catches every deep path and maps `/resume-as-code/<path>` → `resume.rafaracing.com.br/<path>`
- Runs on push to main (deploys immediately) + manual dispatch
- Netlify already redirects via netlify.toml; this closes the GitHub Pages gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014GHQ979tomS1gJyaLcZXaL