### PR TITLE
feat: fill DrAnsay highlights + cal.com booking

### DIFF
--- a/app/data/chat-cards.json
+++ b/app/data/chat-cards.json
@@ -30,7 +30,7 @@
     },
     {
       "q": "How can I schedule a call with you?",
-      "a": "I'd love that. The fastest way is the calendar booking button right here on this page — grab any slot that works for you. Prefer email, WhatsApp, or LinkedIn instead? Those buttons are on the page too. While you're booking: want a quick summary of my experience, or the PDF to share with your team?",
+      "a": "I'd love that. Grab any slot that works for you on my calendar: https://cal.com/rafaelbsathler — or tap the booking button right here on this page. Prefer email, WhatsApp, or LinkedIn instead? Those buttons are on the page too. While you're booking: want a quick summary of my experience, or the PDF to share with your team?",
       "aliases": [
         "How can I schedule a time with you about a position in my company?",
         "How can I contact you?",

--- a/app/data/resume.json
+++ b/app/data/resume.json
@@ -1,12 +1,12 @@
 {
   "basics": {
     "name": "Rafael Bernardo Sathler",
-    "label": "Infrastructure Engineer • DevOps • Platform Engineer • AWS/GCP Cloud Architect",
+    "label": "Platform Engineer • Infrastructure & DevOps • Cloud Security & FinOps • AWS/GCP",
     "image": "assets/images/profile-optimized.jpg",
     "email": "rafaelbsathler@gmail.com",
     "phone": "+55 21 997988682",
     "url": "https://rafilkmp3.github.io/resume-as-code/",
-    "summary": "Platform Engineer with 10+ years evolving from Linux system administration to enterprise-scale cloud-native architecture. Worn many hats across DevOps, infrastructure automation, and platform engineering. Led 8,000-repo GitHub Actions migration, orchestrated zero-downtime Kubernetes upgrades protecting revenue, and delivered $265K+ cost reductions through rightsizing initiatives, spot-instance strategies, and automation serving 5,000+ engineers across AWS/GCP.",
+    "summary": "Platform Engineer, 10+ years across DevOps, infrastructure automation, and cloud-native systems. At a GDPR-regulated German telemedicine provider: self-service IaC (Pulumi + Atlantis) for ~100 engineers, ~€120K/year recurring FinOps savings (orphaned-cluster decommissioning, BigQuery data tiering), security from zero (Cloudflare WAF, Tailscale mesh VPN), and AI-native operations on machine-readable infra. Earlier: an 8,000-repo GitHub Actions migration on a 1,000-node GKE fleet serving 5,000+ engineers, zero-downtime Kubernetes upgrades, $265K+ cumulative.",
     "location": {
       "city": "Rio de Janeiro",
       "countryCode": "BR",

--- a/app/data/resume.json
+++ b/app/data/resume.json
@@ -46,11 +46,13 @@
       "position": "Platform Engineer",
       "url": "https://dransay.com",
       "startDate": "2025-11",
-      "summary": "Platform engineering for DrAnsay (dransay.com), a telehealth platform. [TODO: refine summary]",
+      "summary": "Platform engineering for DrAnsay (dransay.com), a leading German telemedicine provider handling patient health data under GDPR. Own cloud platform, IaC, and security across GCP and Cloudflare — ~€120K/year in cloud savings while hardening the estate.",
       "highlights": [
-        "[TODO: achievement #1 — infrastructure/platform win with a metric]",
-        "[TODO: achievement #2 — CI/CD, reliability, or observability improvement]",
-        "[TODO: achievement #3 — cost, automation, or developer-experience impact]"
+        "Self-service IaC platform: Replaced 100% manual provisioning — GCP and Cloudflare resources in Pulumi, applied via Atlantis by ~100 engineers through pull-request plan/review/apply. One auditable source of truth",
+        "Cloud cost cleanup: Cut ~€8K/month (~€96K/year) — found 24 orphaned Kubernetes clusters, safely decommissioned ~20 plus their unused GCP resources billing for nothing",
+        "FinOps data tiering: Cut production-database cost ~€2K/month (~€24K/year) with pipelines tiering cold data into BigQuery — still fully queryable for analytics",
+        "Network security baseline from scratch: Cloudflare WAF over public endpoints that had none, and a Tailscale mesh VPN placing internal services behind a private network boundary",
+        "AI-assisted operations and hardening: Codified infrastructure gives AI ground truth to read instead of guess — scanning misconfigurations and vulnerabilities and remediating the estate runs orders of magnitude faster"
       ]
     },
     {
@@ -436,7 +438,7 @@
     }
   ],
   "meta": {
-    "lastUpdated": "2025-08-21",
+    "lastUpdated": "2026-07-24",
     "availability": {
       "status": "open_to_work",
       "icon": "🟢",


### PR DESCRIPTION
## What

Replaces the DrAnsay placeholder `[TODO]` summary + highlights in `app/data/resume.json` with real, metric-backed platform wins, and adds the explicit cal.com booking URL to the chatbot's "schedule a call" card.

### DrAnsay highlights (5)
- **Self-service IaC platform** — Pulumi + Atlantis, used by ~100 engineers, PR-based plan/review/apply
- **Cloud cost cleanup** — ~€8K/mo (~€96K/yr) from decommissioning ~20 of 24 orphaned K8s clusters + unused GCP resources
- **FinOps data tiering** — ~€2K/mo (~€24K/yr) tiering cold prod-DB data into BigQuery
- **Network security baseline** — Cloudflare WAF (public endpoints had none) + Tailscale mesh VPN
- **AI-assisted ops & hardening** — codified infra as ground truth for AI → far faster scan/remediate

Refined via advanced-elicitation (Shark Tank → Subtraction): money-forward ordering, security consolidated 3→2 bullets, borrowed marketing stats dropped, all metrics real.

### Chatbot
- `chat-cards.json`: booking answer now includes `https://cal.com/rafaelbsathler`
- Cache auto-busts: content hash is part of the KV key, so `resume.json` edit invalidates stale answers (`p8-zfu49` → new sig). `seed-cards.mjs` re-seeds cards on deploy.

## Verify
- ✅ both JSON files parse
- ✅ worker tests 27/27 (`npm run worker:test`)
- 👀 Netlify preview → check DrAnsay section + chatbot booking reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013q6YoqDdfDeSD1ZU75v9A8