### PR TITLE
feat: train chatbot on recruiter qualifying Qs

### DIFF
--- a/app/data/chat-cards.json
+++ b/app/data/chat-cards.json
@@ -25,7 +25,8 @@
         "Can I download your resume?",
         "Send me your CV",
         "Do you have a PDF version of your resume?",
-        "Can you send me the PDF?"
+        "Can you send me the PDF?",
+        "Can you send your updated CV?"
       ]
     },
     {
@@ -53,6 +54,52 @@
       "aliases": [
         "How was this site built?",
         "Did you build this chatbot?"
+      ]
+    },
+    {
+      "q": "What are your compensation expectations?",
+      "a": "I keep my target number out of public chat, but I won't waste your time either — tell me the range budgeted for the role and I'll say straight away if we're aligned. Structure matters too: full-time, PJ/B2B contract, corp-to-corp, or freelance all change the math. Easiest way to talk specifics is a quick call (https://cal.com/rafaelbsathler) or the email/WhatsApp buttons on this page. What range are you working with?",
+      "aliases": [
+        "What are your salary expectations?",
+        "What's your expected compensation?",
+        "What compensation are you looking for?",
+        "What's your desired salary range?",
+        "How much are you looking to make?"
+      ]
+    },
+    {
+      "q": "What contract types or engagement structures do you accept?",
+      "a": "I'm flexible on structure: full-time employment, contract through my own company (PJ/B2B), corp-to-corp or international contractor, and freelance or short-term — whatever fits how your team hires. I'm based in Rio de Janeiro and work remotely with global teams. Want to sort out the details? Book a call at https://cal.com/rafaelbsathler or use the contact buttons here.",
+      "aliases": [
+        "Are you open to contract work?",
+        "Do you do B2B or PJ contracts?",
+        "Can you work as a contractor?",
+        "Do you work corp to corp?",
+        "Are you available for full-time or contract?",
+        "What engagement structures do you accept?"
+      ]
+    },
+    {
+      "q": "What is your availability to start?",
+      "a": "I'm currently employed, so I'd come with about a 30-day notice period — happy to line the start date up around that. Full-time, contract, and remote are all open. If your timing is tight, let's talk: https://cal.com/rafaelbsathler or the contact buttons here. When are you looking to have someone start?",
+      "aliases": [
+        "When can you start?",
+        "What is your notice period?",
+        "How soon can you join?",
+        "What's your availability?",
+        "Are you available immediately?"
+      ]
+    },
+    {
+      "q": "What is your work authorization?",
+      "a": "I'm a Brazilian citizen based in Rio de Janeiro — fully authorized to work in Brazil, and I work with global teams remotely as a PJ/B2B contractor, so no sponsorship is needed for remote roles. For the right onsite role I'm open to relocating with visa sponsorship. Anything specific your process needs? My calendar and contact buttons are right here (https://cal.com/rafaelbsathler).",
+      "aliases": [
+        "Do you need visa sponsorship?",
+        "Are you authorized to work?",
+        "Where are you authorized to work?",
+        "Do you require sponsorship?",
+        "Are you open to relocation?",
+        "What is your work eligibility?"
       ]
     }
   ]

--- a/app/data/resume.json
+++ b/app/data/resume.json
@@ -447,7 +447,16 @@
         "Full-time",
         "Contract",
         "Remote"
-      ]
+      ],
+      "noticePeriod": "About 30 days — I'm currently employed.",
+      "engagementTypes": [
+        "Full-time employment",
+        "Contract via PJ / B2B (I invoice through my own company)",
+        "Corp-to-corp or international contractor",
+        "Freelance / short-term"
+      ],
+      "workAuthorization": "Brazilian citizen based in Rio de Janeiro — authorized to work in Brazil and available to global teams remotely as a PJ/B2B contractor (no sponsorship needed for remote work). Open to relocating for the right role with visa sponsorship.",
+      "compensationPolicy": "I don't post a public number. Tell me the range budgeted for the role and I'll say straight away if we're aligned — never reveal or estimate a specific figure of my own."
     }
   }
 }

--- a/infrastructure/workers/resume-ai/src/prompt.mjs
+++ b/infrastructure/workers/resume-ai/src/prompt.mjs
@@ -124,8 +124,12 @@ export function formatResumeText(clean) {
 
   if (clean.meta?.availability) {
     const a = clean.meta.availability;
-    out.push('\n### Availability');
+    out.push('\n### Availability & engagement');
     out.push(`${a.text || ''}${a.types?.length ? ` (${a.types.join(', ')})` : ''}`.trim());
+    if (a.noticePeriod) out.push(`Notice period: ${a.noticePeriod}`);
+    if (a.engagementTypes?.length) out.push(`Engagement types I accept: ${a.engagementTypes.join('; ')}`);
+    if (a.workAuthorization) out.push(`Work authorization: ${a.workAuthorization}`);
+    if (a.compensationPolicy) out.push(`Compensation stance: ${a.compensationPolicy}`);
   }
 
   return out.join('\n');
@@ -183,6 +187,12 @@ Q: Can you write me a Python script?
 A: That's outside what I'm here for — I'm Rafael's resume, happy to tell you about my Python and automation experience instead!
 Q: We have a contract role paying $25 per hour, is that in your budget?
 A: I appreciate the offer, but that's roughly half of what I'm currently making, so I'll pass. If the budget has room to grow, I'd be glad to talk — the contact buttons are right here on the page, book a call anytime.
+Q: Do you need visa sponsorship? / What's your work authorization?
+A: I'm a Brazilian citizen based in Rio — fully authorized to work in Brazil, and I work with global teams remotely as a PJ/B2B contractor, so no sponsorship is needed for remote roles. For the right onsite role I'm open to relocating with visa sponsorship. What does your setup look like?
+Q: What's your notice period? / When can you start?
+A: I'm employed right now, so figure about a 30-day notice — happy to plan the start date around that. When are you looking to onboard someone?
+Q: What contract types do you accept?
+A: Flexible on structure — full-time, contract through my own company (PJ/B2B), corp-to-corp, or freelance, whatever fits how your team hires. Want to talk specifics?
 Q: How can I contact you?
 A: Easiest way: the contact buttons right here on this page — email, WhatsApp, LinkedIn, or book a call directly on my calendar. Pick whatever suits you.
 Q: Can I get your resume as a PDF?


### PR DESCRIPTION
## What

Teaches the AI chatbot to field the standard recruiter-qualification checklist (comp, contract type, availability, work authorization) — the exact things recruiters ask before advancing a profile.

### Changes
- **`resume.json` `meta.availability`** (single source, only the worker reads it — not rendered on the page/PDF): notice period (~30d), engagement types (full-time / PJ-B2B / C2C / freelance), work authorization (BR citizen, remote PJ globally, open to relocation w/ sponsorship), and a no-public-number compensation stance.
- **`prompt.mjs`**: surfaces those facts in the system prompt + 3 example answers, so *novel* phrasings answer on-brand (not just exact card matches).
- **`chat-cards.json`**: 4 curated seeded cards (compensation, contract/engagement, availability, work auth) each with 5-6 real-phrasing aliases → instant cached hits; added 'updated CV' alias to the PDF card.

**Compensation stays deflected** — no number is ever posted; the bot asks the recruiter for their range.

## Verify
- ✅ both JSON parse; worker tests 27/27
- ✅ seed builds 49 card entries, no key collisions
- ✅ system prompt contains notice period / engagement types / work auth / PJ-B2B / visa sponsorship
- Cache auto-busts (content hash in KV key); seed-cards re-seeds on deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013q6YoqDdfDeSD1ZU75v9A8