### PR TITLE
feat: chat-log corpus in D1 + bot guards

### DIFF
--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -87,6 +87,13 @@ jobs:
       - name: Build site for prod domain (static assets bundle)
         run: DEPLOY_URL=https://resume.rafaracing.com.br npm run build
 
+      - name: Apply D1 migrations (chat-log schema)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          wranglerVersion: ${{ env.WRANGLER_VERSION }}
+          command: d1 migrations apply resume-ai-logs --remote -c ${{ env.WRANGLER_CONFIG }}
+
       - name: Deploy resume-ai (worker + static assets)
         uses: cloudflare/wrangler-action@v3
         with:

--- a/app/components/ChatHero.astro
+++ b/app/components/ChatHero.astro
@@ -85,6 +85,8 @@ const promptCards = chatCards.cards.map((card) => card.q);
         </svg>
       </button>
     </form>
+    <!-- Invisible Turnstile mount (only used when PUBLIC_TURNSTILE_SITEKEY is set) -->
+    <div id="chat-turnstile" aria-hidden="true"></div>
 
     <!-- Secondary actions -->
     <div class="ch-actions">
@@ -808,6 +810,7 @@ const promptCards = chatCards.cards.map((card) => card.q);
     : 'https://resume.rafaracing.com.br';
 
   const CHAT_STORAGE_KEY = 'resume_chat_history_v1';
+  const CHAT_SESSION_KEY = 'resume_chat_session_v1';
   const CHAT_COOLDOWN_KEY = 'resume_chat_cooldown_until';
   const CHAT_MAX_STORED = 20;
   const CHAT_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -845,6 +848,72 @@ const promptCards = chatCards.cards.map((card) => card.q);
   const skipEl = document.getElementById('chat-skip');
   const scrollCueEl = document.getElementById('chat-scroll-cue');
   const pillEl = document.getElementById('chat-pill');
+
+  // Anonymous conversation grouping for the worker's chat log. sessionStorage
+  // by DESIGN (never localStorage): per-tab, dies on close — groups one
+  // conversation without ever tracking a person across visits.
+  function chatSessionId() {
+    try {
+      let id = sessionStorage.getItem(CHAT_SESSION_KEY);
+      if (!id && window.crypto && typeof crypto.randomUUID === 'function') {
+        id = crypto.randomUUID();
+        sessionStorage.setItem(CHAT_SESSION_KEY, id);
+      }
+      return id || null;
+    } catch (_e) {
+      return null; // storage unavailable — logging just loses the grouping
+    }
+  }
+
+  // Turnstile (bot gate) — build-time gated: without PUBLIC_TURNSTILE_SITEKEY
+  // nothing loads and requests carry no token (worker skips the check unless
+  // its TURNSTILE_SECRET is set — flip both to enable, either alone is inert).
+  const TURNSTILE_SITEKEY = import.meta.env.PUBLIC_TURNSTILE_SITEKEY || '';
+  let turnstileWidgetId = null;
+  function initTurnstile() {
+    if (!TURNSTILE_SITEKEY) return;
+    const s = document.createElement('script');
+    s.src = 'https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit';
+    s.async = true;
+    s.onload = function () {
+      try {
+        turnstileWidgetId = window.turnstile.render('#chat-turnstile', {
+          sitekey: TURNSTILE_SITEKEY,
+          size: 'invisible',
+        });
+      } catch (_e) {
+        /* widget render failed — sends proceed tokenless; server decides */
+      }
+    };
+    document.head.appendChild(s);
+  }
+  function getTurnstileToken() {
+    return new Promise(function (resolve) {
+      if (!TURNSTILE_SITEKEY || !window.turnstile || turnstileWidgetId === null) {
+        resolve(null);
+        return;
+      }
+      const timer = setTimeout(function () {
+        resolve(null); // challenge hung — send tokenless rather than freeze the chat
+      }, 4000);
+      try {
+        window.turnstile.execute(turnstileWidgetId, {
+          callback: function (token) {
+            clearTimeout(timer);
+            resolve(token || null);
+          },
+          'error-callback': function () {
+            clearTimeout(timer);
+            resolve(null);
+          },
+        });
+      } catch (_e) {
+        clearTimeout(timer);
+        resolve(null);
+      }
+    });
+  }
+  initTurnstile();
 
   function trackEvent(eventName, props) {
     try {
@@ -976,14 +1045,17 @@ const promptCards = chatCards.cards.map((card) => card.q);
 
   function sendFeedback(verdict, question, reply) {
     try {
+      const fbPayload = {
+        verdict: verdict,
+        question: String(question).slice(0, 500),
+        reply: String(reply).slice(0, 2000),
+      };
+      const fbSid = chatSessionId();
+      if (fbSid) fbPayload.sessionId = fbSid;
       fetch(CHAT_API_BASE + '/api/feedback', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          verdict: verdict,
-          question: String(question).slice(0, 500),
-          reply: String(reply).slice(0, 2000),
-        }),
+        body: JSON.stringify(fbPayload),
       }).catch(function () {
         /* fire-and-forget */
       });
@@ -1163,7 +1235,7 @@ const promptCards = chatCards.cards.map((card) => card.q);
     inputEl.value = '';
     trackEvent('chat_message_sent', { source: source === 'card' ? 'card' : 'typed' });
 
-    await runInference(message, history);
+    await runInference(message, history, source === 'card' ? 'card' : 'typed');
   }
 
   // Re-run inference for a message already shown in the thread (retry / reload
@@ -1176,10 +1248,10 @@ const promptCards = chatCards.cards.map((card) => card.q);
         ? chatMessages.slice(0, -1)
         : chatMessages;
     trackEvent('chat_message_retried');
-    await runInference(message, buildApiHistory(priorTurns));
+    await runInference(message, buildApiHistory(priorTurns), 'retry');
   }
 
-  async function runInference(message, history) {
+  async function runInference(message, history, source) {
     setBusy(true);
     showTyping();
 
@@ -1189,10 +1261,17 @@ const promptCards = chatCards.cards.map((card) => card.q);
     }, CHAT_TIMEOUT_MS);
 
     try {
+      const payload = { message: message, history: history };
+      const sid = chatSessionId();
+      if (sid) payload.sessionId = sid;
+      if (source) payload.source = source;
+      const turnstileToken = await getTurnstileToken();
+      if (turnstileToken) payload.turnstileToken = turnstileToken;
+
       const res = await fetch(CHAT_API_BASE + '/api/chat', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: message, history: history }),
+        body: JSON.stringify(payload),
         signal: controller.signal,
       });
 

--- a/infrastructure/workers/resume-ai/README.md
+++ b/infrastructure/workers/resume-ai/README.md
@@ -54,8 +54,14 @@ npm run worker:test   # node --test over test/*.test.mjs (pure modules only)
 
 ## Self-improvement loop (real-user log mining)
 
-Every production Q&A is logged to KV (`log:*`, 30-day TTL, no client
-identifiers) and thumbs-up/down feedback to `fb:*`. Mine them with:
+Every conversation turn — cache hits included — is logged to D1
+(`resume-ai-logs`, tables `chats` + `feedback`) with metadata: per-tab
+session id (sessionStorage UUID — never cross-visit), turn number,
+`typed`/`card`/`retry` source, full reply (truncated at 500 chars), model,
+latency, and coarse `request.cf` audience signals (country, city, network
+org). No IP or fingerprint, ever. Retention: 180-day age purge + a
+75%-of-free-tier size fuse, swept by the weekly cron (`scheduled` handler).
+Mine the corpus with:
 
 ```bash
 npm run worker:logs            # human report
@@ -67,12 +73,39 @@ degraded / slow answers, and flags topics that neither the hero cards nor
 `eval/questions.json` cover. The loop:
 
 1. Run `npm run worker:logs` periodically (or before any prompt change).
-2. Fold frequent real questions into `eval/questions.json` as new cases.
+2. Fold graduation candidates (typed by **≥3 distinct sessions** — the
+   report computes this) into `eval/questions.json` as new cases.
 3. Promote the most-asked ones into `app/data/chat-cards.json` — either as a
    hero card, an alias of an existing card, or a `seeded` (cache-only) Q&A.
    That one file feeds the hero UI, the worker's long-TTL cache detection,
    and the KV seeding — no strings to keep in sync by hand.
 4. Fix downvoted answers via prompt tweaks, then `npm run worker:eval`.
+
+Raw questions/replies stay OUT of the public repo and public GitHub issues —
+the repo is public and chat text can contain recruiter PII. Aggregates only.
+
+## Bot & DDoS protection
+
+Layered, mostly free:
+
+- **DDoS (L3/4/7)**: automatic and unmetered on every Cloudflare zone —
+  nothing to configure.
+- **UA blocklist** (`src/d1-log.mjs`): obvious scrapers/CLIs (curl, wget,
+  scrapy, python-requests…) get a 403 before any AI spend. Deliberately
+  narrow so Playwright E2E and the node eval runner still pass.
+- **Per-IP rate limits + daily budgets** (KV): see Architecture summary.
+- **Turnstile** (OFF by default, zero-risk toggle — both halves must be set):
+  1. Dashboard → Turnstile → Add widget (Invisible) for
+     `resume.rafaracing.com.br` → copy sitekey + secret.
+  2. `npx wrangler secret put TURNSTILE_SECRET -c infrastructure/workers/resume-ai/wrangler.toml`
+  3. Build the site with `PUBLIC_TURNSTILE_SITEKEY=<sitekey>` (add it to the
+     worker-deploy workflow build step).
+  Missing secret → worker skips verification; missing sitekey → widget sends
+  no token. siteverify outages fail OPEN (availability beats bot filtering).
+- **Zone toggles (dashboard, one-time, free plan)**: Security → Bots →
+  **Bot Fight Mode** ON; Security → WAF → enable the **Cloudflare Free
+  Managed Ruleset**; optionally add the free plan's one **rate limiting
+  rule** on `/api/chat` as an edge backstop above the Worker's KV limits.
 
 ## Deploy
 
@@ -114,11 +147,13 @@ passing a gateway id that does not exist makes **every** `AI.run` call fail
 - **KV (`RESUME_AI_KV`)**: per-IP fixed-window rate limit 10/10min (chat) and
   20/10min (feedback), global daily budget of 200 model **attempts** (cache
   hits free; fallback retries count), daily feedback-write cap of 100,
-  7-day response cache for history-less questions, 30-day Q&A/feedback logs
-  (no client identifier stored at all). Per-IP limits fail open on KV errors;
-  the daily budgets fail **closed** so exhausting KV can't disable the quota
-  guards. KV counters are best-effort (no atomic increment) — throttles, not
-  exact quotas.
+  7-day response cache for history-less questions. Per-IP limits fail open on
+  KV errors; the daily budgets fail **closed** so exhausting KV can't disable
+  the quota guards. KV counters are best-effort (no atomic increment) —
+  throttles, not exact quotas.
+- **D1 (`CHAT_DB`, `resume-ai-logs`)**: the conversation corpus — see
+  "Self-improvement loop" above. Writes are fire-and-forget (`ctx.waitUntil`,
+  errors swallowed): a D1 outage can never break a chat reply.
 - **CORS**: strict origin allowlist, `Vary: Origin` always, `Origin` echoed
   only when allowed; `no-store`, `nosniff`, `strict-origin-when-cross-origin`
   on every `/api/*` response.

--- a/infrastructure/workers/resume-ai/migrations/0001_create_chat_logs.sql
+++ b/infrastructure/workers/resume-ai/migrations/0001_create_chat_logs.sql
@@ -1,0 +1,46 @@
+-- Chat log corpus — every conversation turn with full metadata, so the
+-- self-improvement loop (analyze-logs → eval/questions.json → hero cards)
+-- reads real production history instead of guesses.
+--
+-- Privacy invariants (do not weaken silently):
+--   * NO IP address, no fingerprint. session_id is a client-generated random
+--     UUID living in sessionStorage — per-tab, dies on close, never cross-visit.
+--   * Geo/network columns are request.cf coarse signals (country, city,
+--     AS organization): company-level, never person-level.
+--   * Retention is enforced by the Worker's scheduled handler: age purge
+--     (RETENTION_DAYS) + size watermark fuse. "Forever" is not a policy.
+
+CREATE TABLE chats (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  session_id TEXT,             -- groups one recruiter conversation (per-tab UUID)
+  turn INTEGER,                -- 1-based position within the session's thread
+  source TEXT,                 -- 'typed' | 'card' | 'retry' (anti feedback-loop tag)
+  q TEXT NOT NULL,
+  reply TEXT,                  -- truncated server-side (REPLY_LOG_MAX)
+  reply_len INTEGER,           -- full length even when reply is truncated
+  model TEXT,
+  ms INTEGER,
+  cached INTEGER NOT NULL DEFAULT 0,
+  degraded INTEGER NOT NULL DEFAULT 0,
+  gateway INTEGER NOT NULL DEFAULT 0,
+  history_len INTEGER,
+  geo_country TEXT,
+  geo_city TEXT,
+  network_org TEXT,            -- request.cf.asOrganization ("Google LLC" beats an IP)
+  turnstile TEXT               -- 'pass' | 'fail' | 'off'
+);
+
+CREATE INDEX idx_chats_ts ON chats (ts);
+CREATE INDEX idx_chats_session ON chats (session_id);
+
+CREATE TABLE feedback (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  session_id TEXT,
+  verdict TEXT NOT NULL,       -- 'up' | 'down'
+  question TEXT,
+  reply TEXT
+);
+
+CREATE INDEX idx_feedback_ts ON feedback (ts);

--- a/infrastructure/workers/resume-ai/scripts/analyze-logs.mjs
+++ b/infrastructure/workers/resume-ai/scripts/analyze-logs.mjs
@@ -1,7 +1,7 @@
-// Self-improvement loop: mines the Worker's KV Q&A logs (log:*) and feedback
-// (fb:*) to surface what REAL visitors ask, then diffs that against the hero
-// suggestion cards and the eval corpus — so cards, curated answers, and evals
-// evolve from production usage instead of guesses.
+// Self-improvement loop: mines the chat-log corpus (D1 `chats` + `feedback`
+// tables — full conversation history with metadata) and diffs what REAL
+// visitors ask against the hero suggestion cards and the eval corpus — so
+// cards, curated answers, and evals evolve from production usage, not guesses.
 //
 // Usage:  npm run worker:logs            (human report)
 //         npm run worker:logs -- --json  (machine-readable, for tooling)
@@ -11,35 +11,31 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
-const NAMESPACE_ID = '1e15da87e1e94016a078b96292a99731';
 const ACCOUNT_ID = 'b76ee39565b02457698bb56c4ed12363';
+const DB_NAME = 'resume-ai-logs';
 
+const CONFIG_PATH = new URL('../wrangler.toml', import.meta.url).pathname;
 const CARDS_PATH = new URL('../src/index.mjs', import.meta.url);
 const EVAL_PATH = new URL('../eval/questions.json', import.meta.url);
 
 // Test/diagnostic noise we generate ourselves — never "real user" signal.
 const NOISE_RE = /\b(?:ping|diag|gw ?test|gwtest|gw \d|reachability|prod unified|post-guardrail)\b|\b\d{4,}\b/i;
 
-function kv(args) {
-  return execFileSync('npx', ['wrangler', 'kv', ...args, '--namespace-id', NAMESPACE_ID, '--remote'], {
-    encoding: 'utf8',
-    env: { ...process.env, CLOUDFLARE_ACCOUNT_ID: ACCOUNT_ID },
-    stdio: ['ignore', 'pipe', 'ignore'],
-    maxBuffer: 16 * 1024 * 1024,
-  });
-}
-
-function listKeys(prefix) {
-  const out = kv(['key', 'list', '--prefix', prefix]);
-  return JSON.parse(out.slice(out.indexOf('['))).map((k) => k.name);
-}
-
-function getValue(key) {
-  try {
-    return JSON.parse(kv(['key', 'get', key]));
-  } catch {
-    return null;
-  }
+function d1Query(sql) {
+  const out = execFileSync(
+    'npx',
+    ['wrangler', 'd1', 'execute', DB_NAME, '--remote', '--json', '--command', sql, '-c', CONFIG_PATH],
+    {
+      encoding: 'utf8',
+      env: { ...process.env, CLOUDFLARE_ACCOUNT_ID: ACCOUNT_ID },
+      // stderr piped (not ignored): wrangler flakes occasionally and a
+      // swallowed stderr turns a transient network error into a mystery.
+      stdio: ['ignore', 'pipe', 'pipe'],
+      maxBuffer: 64 * 1024 * 1024,
+    },
+  );
+  const parsed = JSON.parse(out.slice(out.indexOf('[')));
+  return parsed[0]?.results ?? [];
 }
 
 // Rough topic bucketing — enough to see coverage gaps at a glance.
@@ -61,12 +57,11 @@ function topicOf(q) {
   return 'other';
 }
 
-const logKeys = listKeys('log:');
-const fbKeys = listKeys('fb:');
-console.error(`fetching ${logKeys.length} log + ${fbKeys.length} feedback entries from KV…`);
-
-const logs = logKeys.map((k) => ({ key: k, ...getValue(k) })).filter((l) => typeof l.q === 'string');
-const feedback = fbKeys.map((k) => ({ key: k, ...getValue(k) })).filter(Boolean);
+const logs = d1Query(
+  'SELECT ts, session_id, source, q, reply, reply_len, model, ms, cached, degraded, geo_country, geo_city, network_org FROM chats ORDER BY ts',
+).filter((l) => typeof l.q === 'string');
+const feedback = d1Query('SELECT ts, session_id, verdict, question, reply FROM feedback ORDER BY ts');
+console.error(`fetched ${logs.length} chat rows + ${feedback.length} feedback rows from D1…`);
 
 const real = logs.filter((l) => !NOISE_RE.test(l.q));
 const byTopic = {};
@@ -83,15 +78,43 @@ const gaps = Object.keys(byTopic).filter(
   (t) => t !== 'other' && t !== 'injection' && !TOPICS.find(([n]) => n === t)?.[1].test(coveredText),
 );
 
+// Card/eval graduation candidates: TYPED questions asked in >= 3 distinct
+// sessions (card clicks excluded — they would only echo the cards back).
+const normalize = (q) => q.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, '').replace(/\s+/g, ' ').trim();
+const typedBySessions = new Map();
+for (const l of real) {
+  if (l.source === 'card' || !l.session_id) continue;
+  const key = normalize(l.q);
+  if (!typedBySessions.has(key)) typedBySessions.set(key, { q: l.q, sessions: new Set() });
+  typedBySessions.get(key).sessions.add(l.session_id);
+}
+const graduationCandidates = [...typedBySessions.values()]
+  .filter((e) => e.sessions.size >= 3)
+  .map((e) => ({ q: e.q, distinctSessions: e.sessions.size }))
+  .sort((a, b) => b.distinctSessions - a.distinctSessions);
+
+// Conversation + audience shape (coarse request.cf metadata — company-level).
+const sessions = new Set(real.filter((l) => l.session_id).map((l) => l.session_id));
+const orgCounts = {};
+for (const l of real) if (l.network_org) orgCounts[l.network_org] = (orgCounts[l.network_org] || 0) + 1;
+const topOrgs = Object.entries(orgCounts).sort((a, b) => b[1] - a[1]).slice(0, 10);
+
 const downvoted = feedback.filter((f) => f.verdict === 'down');
-const degraded = logs.filter((l) => l.model === 'fallback-static' || l.model === 'leak-guard');
-const slow = real.filter((l) => l.ms > 8000);
+const degraded = logs.filter((l) => l.degraded === 1 || l.model === 'fallback-static' || l.model === 'leak-guard');
+const slow = real.filter((l) => l.cached !== 1 && l.ms > 8000);
 
 const report = {
-  totals: { logs: logs.length, realUserQuestions: real.length, feedback: feedback.length },
+  totals: {
+    rows: logs.length,
+    realUserQuestions: real.length,
+    distinctSessions: sessions.size,
+    feedback: feedback.length,
+  },
   topics: Object.fromEntries(Object.entries(byTopic).map(([t, qs]) => [t, qs.length])),
   questionsByTopic: byTopic,
   uncoveredTopics: gaps,
+  graduationCandidates,
+  topNetworkOrgs: Object.fromEntries(topOrgs),
   downvoted: downvoted.map((f) => ({ q: f.question, reply: (f.reply || '').slice(0, 160) })),
   degradedReplies: degraded.map((l) => ({ q: l.q, model: l.model })),
   slowReplies: slow.map((l) => ({ q: l.q, ms: l.ms })),
@@ -100,18 +123,29 @@ const report = {
 if (process.argv.includes('--json')) {
   console.log(JSON.stringify(report, null, 2));
 } else {
-  console.log('\n📊 resume-ai — real-user question mining');
-  console.log(`   ${report.totals.realUserQuestions} real questions (${report.totals.logs} logs, noise filtered)\n`);
+  console.log('\n📊 resume-ai — real-user question mining (D1 corpus)');
+  console.log(
+    `   ${report.totals.realUserQuestions} real questions in ${report.totals.distinctSessions} sessions (${report.totals.rows} rows, noise filtered)\n`,
+  );
   for (const [topic, qs] of Object.entries(byTopic).sort((a, b) => b[1].length - a[1].length)) {
     console.log(`   ${topic} (${qs.length})`);
     for (const q of [...new Set(qs)].slice(0, 5)) console.log(`     · ${q}`);
   }
+  if (topOrgs.length) {
+    console.log('\n🏢 top visitor networks (request.cf asOrganization):');
+    for (const [org, n] of topOrgs.slice(0, 5)) console.log(`     · ${org} (${n})`);
+  }
   if (gaps.length) console.log(`\n⚠️  topics users ask that cards/eval do not cover: ${gaps.join(', ')}`);
+  if (graduationCandidates.length) {
+    console.log('\n🎓 card/eval graduation candidates (typed by ≥3 distinct sessions):');
+    for (const c of graduationCandidates.slice(0, 5))
+      console.log(`     · ${c.q} (${c.distinctSessions} sessions)`);
+  }
   if (downvoted.length) {
     console.log(`\n👎 downvoted answers (${downvoted.length}) — fix these first:`);
     for (const f of downvoted) console.log(`     · ${f.q}`);
   }
   if (degraded.length) console.log(`\n🩹 degraded/guarded replies: ${degraded.length}`);
   if (slow.length) console.log(`🐢 replies >8s: ${slow.length}`);
-  console.log('\nNext: fold frequent uncovered questions into eval/questions.json and, if card-worthy, into the hero cards + seed-cards.mjs.');
+  console.log('\nNext: fold graduation candidates into eval/questions.json and, if card-worthy, into the hero cards + seed-cards.mjs.');
 }

--- a/infrastructure/workers/resume-ai/src/d1-log.mjs
+++ b/infrastructure/workers/resume-ai/src/d1-log.mjs
@@ -1,0 +1,125 @@
+// Chat-log corpus (D1) + bot/Turnstile guards.
+// D1 writes are fire-and-forget from the caller's ctx.waitUntil — a logging
+// failure must never break a chat reply. Pure helpers stay node-testable.
+
+export const RETENTION_DAYS = 180; // age purge — the retention POLICY
+export const REPLY_LOG_MAX = 500; // reply text stored truncated; reply_len keeps the true size
+// Size watermark FUSE: D1 free tier caps a database at 500 MB. Trim oldest
+// rows in bounded batches when past 75% — SQLite file size does not shrink on
+// DELETE (pages are reused), so never loop-until-under-watermark.
+export const SIZE_WATERMARK_BYTES = Math.floor(0.75 * 500 * 1024 * 1024);
+export const WATERMARK_BATCH = 10_000;
+
+// Obvious non-browser scrapers/CLIs. Deliberately NARROW: no "headless"
+// entries (Playwright E2E must pass) and nothing matching node/undici (the
+// eval runner must pass). Real bot defense is Turnstile + zone-level Bot
+// Fight Mode; this only stops drive-by curl spam from burning AI quota.
+// "(?<!cu)bot\b" catches Googlebot/Bingbot/…bot while sparing Cubot phones.
+const BOT_UA_RE =
+  /(?<!cu)bot\b|crawler|spider|scrapy|python-requests|python-httpx|aiohttp|go-http-client|libwww|apache-httpclient|okhttp|^(?:curl|wget)\//i;
+
+/** @returns {'browser'|'bot'} coarse UA class; missing UA on an API POST is bot-like */
+export function classifyUserAgent(ua) {
+  if (!ua || BOT_UA_RE.test(ua)) return 'bot';
+  return 'browser';
+}
+
+/** Coarse request.cf metadata — company-level signal, never person-level. */
+export function cfMetadata(request) {
+  const cf = request?.cf || {};
+  const clip = (v) => (typeof v === 'string' && v ? v.slice(0, 100) : null);
+  return {
+    geoCountry: clip(cf.country),
+    geoCity: clip(cf.city),
+    networkOrg: clip(cf.asOrganization),
+  };
+}
+
+/**
+ * Verify a Turnstile token. Env-gated by the caller: only runs when the
+ * TURNSTILE_SECRET Worker secret is set. Verification-service outage fails
+ * OPEN (availability of the chat beats bot filtering, same philosophy as the
+ * per-IP rate limit); a definite "invalid token" verdict fails the request.
+ * @returns {Promise<'pass'|'fail'>}
+ */
+export async function verifyTurnstile(secret, token, ip) {
+  try {
+    const form = new FormData();
+    form.append('secret', secret);
+    form.append('response', token || '');
+    if (ip && ip !== 'unknown') form.append('remoteip', ip);
+    const res = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      body: form,
+    });
+    if (!res.ok) return 'pass'; // siteverify outage — fail open
+    const data = await res.json();
+    return data.success ? 'pass' : 'fail';
+  } catch {
+    return 'pass'; // network failure — fail open
+  }
+}
+
+/** INSERT one chat turn. Caller wraps in ctx.waitUntil(...) — never awaited inline. */
+export function logChat(db, e) {
+  return db
+    .prepare(
+      `INSERT INTO chats (session_id, turn, source, q, reply, reply_len, model, ms,
+         cached, degraded, gateway, history_len, geo_country, geo_city, network_org, turnstile)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      e.sessionId ?? null,
+      e.turn ?? null,
+      e.source ?? null,
+      e.q,
+      typeof e.reply === 'string' ? e.reply.slice(0, REPLY_LOG_MAX) : null,
+      typeof e.reply === 'string' ? e.reply.length : null,
+      e.model ?? null,
+      e.ms ?? null,
+      e.cached ? 1 : 0,
+      e.degraded ? 1 : 0,
+      e.gateway ? 1 : 0,
+      e.historyLen ?? null,
+      e.geoCountry,
+      e.geoCity,
+      e.networkOrg,
+      e.turnstile ?? 'off',
+    )
+    .run();
+}
+
+/** INSERT one feedback verdict. Caller wraps in ctx.waitUntil(...). */
+export function logFeedback(db, e) {
+  return db
+    .prepare(`INSERT INTO feedback (session_id, verdict, question, reply) VALUES (?, ?, ?, ?)`)
+    .bind(e.sessionId ?? null, e.verdict, e.question ?? null, e.reply ?? null)
+    .run();
+}
+
+/**
+ * Weekly retention sweep (scheduled handler).
+ * Age purge is the policy (GDPR storage limitation); the size watermark is a
+ * bot-flood fuse that trims ONE bounded batch per run.
+ */
+export async function runRetention(db) {
+  const purged = await db
+    .prepare(`DELETE FROM chats WHERE ts < datetime('now', ?)`)
+    .bind(`-${RETENTION_DAYS} days`)
+    .run();
+  await db
+    .prepare(`DELETE FROM feedback WHERE ts < datetime('now', ?)`)
+    .bind(`-${RETENTION_DAYS} days`)
+    .run();
+
+  const probe = await db.prepare('SELECT 1').run();
+  let trimmed = 0;
+  if ((probe.meta?.size_after ?? 0) > SIZE_WATERMARK_BYTES) {
+    const res = await db
+      .prepare(`DELETE FROM chats WHERE id IN (SELECT id FROM chats ORDER BY ts ASC LIMIT ?)`)
+      .bind(WATERMARK_BATCH)
+      .run();
+    trimmed = res.meta?.changes ?? 0;
+  }
+  return { purged: purged.meta?.changes ?? 0, trimmed };
+}

--- a/infrastructure/workers/resume-ai/src/guards.mjs
+++ b/infrastructure/workers/resume-ai/src/guards.mjs
@@ -31,10 +31,27 @@ export function resolveCorsOrigin(originHeader) {
   return null;
 }
 
+// Optional client metadata (additive to the frozen contract — old clients
+// simply omit them). sessionId is a client-generated UUID from sessionStorage;
+// anything non-UUID-shaped is dropped (not rejected) so the log never stores
+// attacker-controlled junk as an identifier.
+const SESSION_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SOURCES = new Set(['typed', 'card', 'retry']);
+
+/** @returns {string|null} the sessionId if well-formed, else null (never an error) */
+export function sanitizeSessionId(value) {
+  return typeof value === 'string' && SESSION_ID_RE.test(value) ? value.toLowerCase() : null;
+}
+
+/** @returns {string|null} the source tag if known, else null (never an error) */
+export function sanitizeSource(value) {
+  return typeof value === 'string' && SOURCES.has(value) ? value : null;
+}
+
 /**
  * Validates POST /api/chat body per the frozen API contract.
  * @param {unknown} body parsed JSON
- * @returns {{ok:true, message:string, history:Array<{role:string,content:string}>} | {error:string, status:number}}
+ * @returns {{ok:true, message:string, history:Array<{role:string,content:string}>, sessionId:string|null, source:string|null, turnstileToken:string|null} | {error:string, status:number}}
  */
 export function validateChatBody(body) {
   if (!body || typeof body !== 'object' || Array.isArray(body)) {
@@ -68,7 +85,18 @@ export function validateChatBody(body) {
     }
     history = body.history.map((e) => ({ role: e.role, content: e.content }));
   }
-  return { ok: true, message, history };
+  const turnstileToken =
+    typeof body.turnstileToken === 'string' && body.turnstileToken.length <= 2048
+      ? body.turnstileToken
+      : null;
+  return {
+    ok: true,
+    message,
+    history,
+    sessionId: sanitizeSessionId(body.sessionId),
+    source: sanitizeSource(body.source),
+    turnstileToken,
+  };
 }
 
 /**
@@ -89,7 +117,13 @@ export function validateFeedbackBody(body) {
   if (body.reply !== undefined && (typeof body.reply !== 'string' || body.reply.length > 2000)) {
     return { error: 'reply must be a string of max 2000 characters', status: 400 };
   }
-  return { ok: true, verdict: body.verdict, question: body.question, reply: body.reply };
+  return {
+    ok: true,
+    verdict: body.verdict,
+    question: body.question,
+    reply: body.reply,
+    sessionId: sanitizeSessionId(body.sessionId),
+  };
 }
 
 /**

--- a/infrastructure/workers/resume-ai/src/index.mjs
+++ b/infrastructure/workers/resume-ai/src/index.mjs
@@ -17,6 +17,14 @@ import {
 } from './guards.mjs';
 import { aiRunViaGateway, extractAiText, postProcess, detectPromptLeak } from './ai.mjs';
 import { cacheKey as buildCacheKey } from './cache-version.mjs';
+import {
+  classifyUserAgent,
+  cfMetadata,
+  verifyTurnstile,
+  logChat,
+  logFeedback,
+  runRetention,
+} from './d1-log.mjs';
 
 // Fallback chain — free-tier models hang/fail routinely; every step has a hard
 // timeout so the next one always gets a chance (see ai.mjs).
@@ -43,7 +51,6 @@ const RATE_LIMIT_FEEDBACK = { max: 20, ttl: 600 }; // 20 req / 10 min per IP
 const DAILY_BUDGET = 200;
 const DAILY_FEEDBACK_BUDGET = 100; // caps fb:* KV writes so feedback spam can't exhaust the KV write quota
 const CACHE_TTL = 7 * 24 * 60 * 60; // 7 days (normal questions)
-const LOG_TTL = 30 * 24 * 60 * 60; // 30 days
 
 // The hero suggestion cards are the primary demo surface — once warmed they
 // should answer INSTANTLY and never re-spend neurons. Their cached answers get
@@ -157,7 +164,14 @@ async function handleChat(request, env, ctx, corsOrigin) {
   if (!validated.ok) {
     return jsonResponse(validated.status, { error: validated.error }, corsOrigin);
   }
-  const { message, history } = validated;
+  const { message, history, sessionId, source, turnstileToken } = validated;
+
+  // Obvious scraper/CLI user agents never reach the AI (or the log). Narrow
+  // list by design — see d1-log.mjs; Turnstile + zone Bot Fight Mode do the
+  // real work. 403 with a stable code so it is distinguishable from CORS 403s.
+  if (classifyUserAgent(request.headers.get('User-Agent')) === 'bot') {
+    return jsonResponse(403, { error: 'Automated clients are not allowed', code: 'bot' }, corsOrigin);
+  }
 
   const ip = request.headers.get('CF-Connecting-IP') || 'unknown';
   const rl = await rateLimit(env.RESUME_AI_KV, 'rl', ip, RATE_LIMIT_CHAT);
@@ -169,6 +183,11 @@ async function handleChat(request, env, ctx, corsOrigin) {
     );
   }
 
+  // Coarse request.cf metadata (country/city/AS org) — attached to every log
+  // row. Company-level signal; deliberately nothing person-level (no IP, ever).
+  const meta = cfMetadata(request);
+  const turn = Math.floor(history.length / 2) + 1;
+
   // Response cache — only for history-less questions (a follow-up depends on
   // conversation context, so caching it would serve wrong answers). The key's
   // version is a hash of the resume content (see cache-version.mjs), so editing
@@ -178,10 +197,43 @@ async function handleChat(request, env, ctx, corsOrigin) {
     try {
       const cached = await env.RESUME_AI_KV.get(cacheKey, 'json');
       if (cached && cached.reply) {
+        // Cache hits ARE logged (they were the corpus's biggest blind spot:
+        // the most popular questions are exactly the ones served from cache).
+        // Turnstile is skipped here — a cache hit spends no AI quota.
+        ctx.waitUntil(
+          logChat(env.CHAT_DB, {
+            sessionId,
+            turn,
+            source,
+            q: message,
+            reply: cached.reply,
+            model: cached.model,
+            ms: 0,
+            cached: true,
+            historyLen: history.length,
+            ...meta,
+            turnstile: env.TURNSTILE_SECRET ? 'skip' : 'off',
+          }).catch(() => {}),
+        );
         return jsonResponse(200, { reply: cached.reply, model: cached.model, cached: true }, corsOrigin);
       }
     } catch {
       // fail open — treat as cache miss
+    }
+  }
+
+  // Turnstile gate — env-gated like AI_GATEWAY_ID: no TURNSTILE_SECRET, no
+  // check (zero-risk toggle). Runs only in front of real AI spend; the
+  // verification service failing open is deliberate (see d1-log.mjs).
+  let turnstile = 'off';
+  if (env.TURNSTILE_SECRET) {
+    turnstile = await verifyTurnstile(env.TURNSTILE_SECRET, turnstileToken, ip);
+    if (turnstile === 'fail') {
+      return jsonResponse(
+        403,
+        { error: 'Bot check failed — please reload the page and try again.', code: 'turnstile' },
+        corsOrigin,
+      );
     }
   }
 
@@ -258,16 +310,25 @@ async function handleChat(request, env, ctx, corsOrigin) {
       }).catch(() => {}),
     );
   }
-  // Fire-and-forget Q&A log — learning/eval corpus. Deliberately NO client
-  // identifier: a djb2 "hash" of an IPv4 is brute-forceable in minutes, so
-  // storing it would be storing the IP.
-  const logKey = `log:${new Date().toISOString()}:${Math.random().toString(36).slice(2, 8)}`;
+  // Fire-and-forget conversation log — the learning/eval corpus (D1, was KV).
+  // Deliberately NO IP or fingerprint: session_id is a per-tab client UUID and
+  // geo/network columns are coarse request.cf signals (company-level only).
   ctx.waitUntil(
-    env.RESUME_AI_KV.put(
-      logKey,
-      JSON.stringify({ q: message, replyLen: reply.length, model: modelUsed, ms, cached: false }),
-      { expirationTtl: LOG_TTL },
-    ).catch(() => {}),
+    logChat(env.CHAT_DB, {
+      sessionId,
+      turn,
+      source,
+      q: message,
+      reply,
+      model: modelUsed,
+      ms,
+      cached: false,
+      degraded,
+      gateway: viaGateway,
+      historyLen: history.length,
+      ...meta,
+      turnstile,
+    }).catch(() => {}),
   );
 
   const payload = { reply, model: modelUsed, cached: false };
@@ -298,22 +359,18 @@ async function handleFeedback(request, env, ctx, corsOrigin) {
     );
   }
 
-  // Daily cap on feedback persistence (fail-closed): without it, feedback spam
-  // could exhaust the KV free tier's write quota and knock out every KV-backed
-  // guard. Over cap → feedback is silently dropped, response stays 204.
+  // Daily cap on feedback persistence (fail-closed): caps how many D1 rows
+  // feedback spam can write per day. Over cap → feedback is silently dropped,
+  // response stays 204.
   const day = new Date().toISOString().slice(0, 10);
   if (await bumpCounter(env.RESUME_AI_KV, `budget-fb:${day}`, DAILY_FEEDBACK_BUDGET, 172_800, true)) {
-    const fbKey = `fb:${new Date().toISOString()}:${Math.random().toString(36).slice(2, 8)}`;
     ctx.waitUntil(
-      env.RESUME_AI_KV.put(
-        fbKey,
-        JSON.stringify({
-          verdict: validated.verdict,
-          question: validated.question,
-          reply: validated.reply,
-        }),
-        { expirationTtl: LOG_TTL },
-      ).catch(() => {}),
+      logFeedback(env.CHAT_DB, {
+        sessionId: validated.sessionId,
+        verdict: validated.verdict,
+        question: validated.question,
+        reply: validated.reply,
+      }).catch(() => {}),
     );
   }
 
@@ -368,5 +425,16 @@ export default {
     // static-assets layer serves the site directly without invoking the Worker.
     // Anything landing here is an unknown /api/* route.
     return jsonResponse(404, { error: 'Not found' }, corsOrigin);
+  },
+
+  // Weekly retention sweep (cron in wrangler.toml): age purge is the policy,
+  // size watermark is the bot-flood fuse. See runRetention in d1-log.mjs.
+  async scheduled(_event, env, _ctx) {
+    try {
+      const { purged, trimmed } = await runRetention(env.CHAT_DB);
+      console.log(`[resume-ai] retention sweep: purged=${purged} trimmed=${trimmed}`);
+    } catch (err) {
+      console.error('[resume-ai] retention sweep failed:', err);
+    }
   },
 };

--- a/infrastructure/workers/resume-ai/src/prompt.mjs
+++ b/infrastructure/workers/resume-ai/src/prompt.mjs
@@ -220,6 +220,7 @@ Use this ONLY to judge offers and negotiate the way I do:
 8. Refuse off-topic requests (coding tasks, general assistant work, politics, current events, etc.) politely, steering back to my experience and skills.
 9. For salary or compensation questions, suggest discussing directly with me.
 10. My availability: ${availabilityText}.
+11. When the conversation turns serious (role details, availability, fit), it's natural to ask ONCE, casually, who I'm talking with — e.g. "By the way, who am I chatting with — and which company are you hiring for?". Never insist, never repeat if they don't answer, never make it a condition for answering.
 
 REMEMBER: you ARE Rafael's resume speaking in the first person — "I", "my", "me". Never refer to Rafael in the third person ("Rafael is", "contact him", "his experience"). Even when greeted with "Hi Rafael", answer as me.`;
 }

--- a/infrastructure/workers/resume-ai/test/d1-log.test.mjs
+++ b/infrastructure/workers/resume-ai/test/d1-log.test.mjs
@@ -1,0 +1,164 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyUserAgent,
+  cfMetadata,
+  logChat,
+  REPLY_LOG_MAX,
+  RETENTION_DAYS,
+  SIZE_WATERMARK_BYTES,
+} from '../src/d1-log.mjs';
+import { sanitizeSessionId, sanitizeSource, validateChatBody } from '../src/guards.mjs';
+
+// --- classifyUserAgent -------------------------------------------------------
+
+test('UA: real browsers pass', () => {
+  const chrome =
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36';
+  const iphone =
+    'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1';
+  assert.equal(classifyUserAgent(chrome), 'browser');
+  assert.equal(classifyUserAgent(iphone), 'browser');
+});
+
+test('UA: obvious scrapers/CLIs are bots', () => {
+  for (const ua of [
+    'curl/8.6.0',
+    'Wget/1.21',
+    'python-requests/2.32.0',
+    'Scrapy/2.11 (+https://scrapy.org)',
+    'Googlebot/2.1 (+http://www.google.com/bot.html)',
+    'facebookexternalhit/1.1 crawler',
+    'Go-http-client/2.0',
+    'okhttp/4.12.0',
+  ]) {
+    assert.equal(classifyUserAgent(ua), 'bot', ua);
+  }
+});
+
+test('UA: missing UA on an API POST is bot-like', () => {
+  assert.equal(classifyUserAgent(''), 'bot');
+  assert.equal(classifyUserAgent(null), 'bot');
+  assert.equal(classifyUserAgent(undefined), 'bot');
+});
+
+test('UA: Playwright/headless and node/undici must PASS (E2E + eval runner)', () => {
+  const headless =
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/126.0 Safari/537.36';
+  assert.equal(classifyUserAgent(headless), 'browser');
+  assert.equal(classifyUserAgent('node'), 'browser');
+  assert.equal(classifyUserAgent('undici'), 'browser');
+});
+
+// --- cfMetadata --------------------------------------------------------------
+
+test('cfMetadata: extracts coarse fields, clips length, nulls when absent', () => {
+  const m = cfMetadata({
+    cf: { country: 'DE', city: 'Munich', asOrganization: 'Deutsche Telekom AG' },
+  });
+  assert.deepEqual(m, { geoCountry: 'DE', geoCity: 'Munich', networkOrg: 'Deutsche Telekom AG' });
+  assert.deepEqual(cfMetadata({}), { geoCountry: null, geoCity: null, networkOrg: null });
+  assert.deepEqual(cfMetadata(undefined), { geoCountry: null, geoCity: null, networkOrg: null });
+  const long = cfMetadata({ cf: { country: 'x'.repeat(300) } });
+  assert.equal(long.geoCountry.length, 100);
+});
+
+// --- logChat (db stub) -------------------------------------------------------
+
+function dbStub(captured) {
+  return {
+    prepare(sql) {
+      captured.sql = sql;
+      return {
+        bind(...args) {
+          captured.args = args;
+          return { run: async () => ({ meta: { changes: 1 } }) };
+        },
+      };
+    },
+  };
+}
+
+test('logChat: truncates reply to REPLY_LOG_MAX but keeps true reply_len', async () => {
+  const captured = {};
+  const reply = 'r'.repeat(REPLY_LOG_MAX + 200);
+  await logChat(dbStub(captured), {
+    q: 'q',
+    reply,
+    geoCountry: null,
+    geoCity: null,
+    networkOrg: null,
+  });
+  const stored = captured.args[4];
+  const storedLen = captured.args[5];
+  assert.equal(stored.length, REPLY_LOG_MAX);
+  assert.equal(storedLen, REPLY_LOG_MAX + 200);
+});
+
+test('logChat: booleans become 0/1, missing optionals become null', async () => {
+  const captured = {};
+  await logChat(dbStub(captured), {
+    q: 'hello',
+    reply: 'world',
+    cached: true,
+    geoCountry: 'BR',
+    geoCity: null,
+    networkOrg: null,
+  });
+  assert.equal(captured.args[0], null); // sessionId
+  assert.equal(captured.args[8], 1); // cached
+  assert.equal(captured.args[9], 0); // degraded
+  assert.equal(captured.args[15], 'off'); // turnstile default
+});
+
+// --- retention constants (documented invariants) -----------------------------
+
+test('retention: policy and fuse hold their documented values', () => {
+  assert.equal(RETENTION_DAYS, 180);
+  assert.equal(SIZE_WATERMARK_BYTES, Math.floor(0.75 * 500 * 1024 * 1024));
+});
+
+// --- guards: new optional chat-body fields -----------------------------------
+
+test('sessionId: well-formed UUID accepted (lowercased), junk dropped to null', () => {
+  const id = '9B2D8E1A-4C3F-4A5B-9C7D-1E2F3A4B5C6D';
+  assert.equal(sanitizeSessionId(id), id.toLowerCase());
+  assert.equal(sanitizeSessionId('not-a-uuid'), null);
+  assert.equal(sanitizeSessionId('x'.repeat(500)), null);
+  assert.equal(sanitizeSessionId(42), null);
+  assert.equal(sanitizeSessionId(undefined), null);
+});
+
+test('source: known tags accepted, junk dropped to null', () => {
+  assert.equal(sanitizeSource('typed'), 'typed');
+  assert.equal(sanitizeSource('card'), 'card');
+  assert.equal(sanitizeSource('retry'), 'retry');
+  assert.equal(sanitizeSource('evil'), null);
+  assert.equal(sanitizeSource(7), null);
+});
+
+test('chat body: metadata fields are optional and never reject a request', () => {
+  const bare = validateChatBody({ message: 'hi' });
+  assert.equal(bare.ok, true);
+  assert.equal(bare.sessionId, null);
+  assert.equal(bare.source, null);
+  assert.equal(bare.turnstileToken, null);
+
+  const full = validateChatBody({
+    message: 'hi',
+    sessionId: '9b2d8e1a-4c3f-4a5b-9c7d-1e2f3a4b5c6d',
+    source: 'card',
+    turnstileToken: 'tok',
+  });
+  assert.equal(full.ok, true);
+  assert.equal(full.sessionId, '9b2d8e1a-4c3f-4a5b-9c7d-1e2f3a4b5c6d');
+  assert.equal(full.source, 'card');
+  assert.equal(full.turnstileToken, 'tok');
+
+  // junk metadata degrades to null instead of 400 — old/hostile clients alike
+  const junk = validateChatBody({ message: 'hi', sessionId: 'zzz', source: 'evil', turnstileToken: 'x'.repeat(3000) });
+  assert.equal(junk.ok, true);
+  assert.equal(junk.sessionId, null);
+  assert.equal(junk.source, null);
+  assert.equal(junk.turnstileToken, null);
+});

--- a/infrastructure/workers/resume-ai/wrangler.toml
+++ b/infrastructure/workers/resume-ai/wrangler.toml
@@ -28,6 +28,21 @@ remote = true
 binding = "RESUME_AI_KV"
 id = "1e15da87e1e94016a078b96292a99731"
 
+# Chat-log corpus (self-improvement loop). D1, not KV: queryable SQL, 100k
+# writes/day free (vs KV's ~1k), no forced TTL — retention is enforced by the
+# scheduled handler below (age purge + size watermark). Local dev uses
+# wrangler's local D1 simulator; run `npm run worker:db:migrate:local` once.
+[[d1_databases]]
+binding = "CHAT_DB"
+database_name = "resume-ai-logs"
+database_id = "d146e1df-5b34-4d90-8781-2b3ba059b7a2"
+migrations_dir = "migrations"
+
+# Weekly retention sweep (scheduled handler in src/index.mjs): age purge
+# (policy) + 75%-of-free-tier size watermark (fuse). Mondays 04:00 UTC.
+[triggers]
+crons = ["0 4 * * 1"]
+
 # AI Gateway "resume-ai": logs on, response cache (5min), rate limit 50/min,
 # spend cap $0.01/mo (keeps it free — blocks the instant any billable cost
 # accrues), retry 3x, authenticated (Worker binding auto-authenticates). A

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "seed:cards": "node infrastructure/workers/resume-ai/scripts/seed-cards.mjs && npx wrangler kv bulk put infrastructure/workers/resume-ai/.cards-bulk.json --namespace-id 1e15da87e1e94016a078b96292a99731 --remote",
     "site:deploy": "DEPLOY_URL=https://resume.rafaracing.com.br npm run build && npm run worker:deploy && npm run seed:cards",
     "worker:test": "node --test \"infrastructure/workers/resume-ai/test/*.test.mjs\"",
+    "worker:db:migrate:local": "npx wrangler d1 migrations apply resume-ai-logs --local -c infrastructure/workers/resume-ai/wrangler.toml",
+    "worker:db:migrate": "npx wrangler d1 migrations apply resume-ai-logs --remote -c infrastructure/workers/resume-ai/wrangler.toml",
     "worker:eval": "node infrastructure/workers/resume-ai/eval/run-eval.mjs",
     "worker:logs": "node infrastructure/workers/resume-ai/scripts/analyze-logs.mjs",
     "prepare": "husky || true"


### PR DESCRIPTION
## What

Replaces KV Q&A logging with a **metadata-rich D1 conversation corpus** so the self-improvement loop (analyze → eval → hero cards) reads real production history — plus layered bot protection.

### Chat archive (D1 `resume-ai-logs`)
- Every turn logged, **cache hits included** (previously the biggest blind spot — the most popular questions were exactly the ones served from cache and never logged)
- Metadata per row: `session_id` (per-tab sessionStorage UUID — never cross-visit), `turn`, `source` (`typed`/`card`/`retry`), full reply (truncated at 500 chars, true length kept), model, latency, `cached`/`degraded`/`gateway` flags, and coarse `request.cf` audience signals (country, city, **network org** — "Google LLC" beats an IP)
- **No IP, no fingerprint, ever** — same privacy invariant as before, now documented in the migration header
- Writes are fire-and-forget (`ctx.waitUntil`): a D1 outage can never break a chat reply
- Feedback (`fb:*` KV) → D1 `feedback` table, same daily spam cap

### Retention (weekly cron, `scheduled` handler)
- **Policy:** 180-day age purge (GDPR storage-limitation)
- **Fuse:** 75%-of-500MB size watermark via `meta.size_after`, bounded oldest-first batches (SQLite file size doesn't shrink on DELETE — no trim loops)

### Bot & DDoS protection
- UA blocklist 403s obvious scrapers/CLIs **before any AI spend** — deliberately narrow: Playwright E2E and the node eval runner (`user-agent: node`) pass, pinned by tests
- **Turnstile, env-gated & inert by default:** worker verifies only when `TURNSTILE_SECRET` is set; widget loads only when `PUBLIC_TURNSTILE_SITEKEY` is set at build. siteverify outages fail OPEN (availability beats bot filtering). Enable steps in the worker README
- Zone-level checklist (README): Bot Fight Mode, free WAF managed ruleset, optional edge rate-limit rule. L3/4/7 DDoS is automatic on every CF zone

### Self-improvement loop
- `npm run worker:logs` now mines D1: topics, distinct sessions, top visitor networks, downvoted/degraded/slow replies, and **card/eval graduation candidates** (typed by ≥3 distinct sessions — card clicks excluded to avoid the self-reinforcing card loop)
- Raw chat text stays out of the public repo/issues — aggregates only

### CI
- `worker-deploy.yml` applies D1 migrations before deploy (main pushes only; PRs run tests + dry-run bundle check as before)

## Verification
- 38/38 unit tests green (`npm run worker:test`), incl. new UA-filter, cfMetadata, truncation, and guard-field tests
- Live local probe: bot UA → 403 `code:bot`; real chat → reply + D1 row with full metadata (session, turn, source, geo, network org)
- `scheduled` handler probed via `--test-scheduled`: `retention sweep: purged=0 trimmed=0`
- `wrangler deploy --dry-run` bundle check green (CHAT_DB binding resolved)
- Migration applied to prod D1; `npm run worker:logs` runs end-to-end against it
- Site build green

## Free-tier arithmetic
D1: 100k row-writes/day vs chat volume (~40/week) — 3 orders of magnitude headroom; KV write pressure *drops* (log writes moved out). AI quota unchanged — bot 403s happen before the model chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1rsqobA2JKHrrUgmtRM7D