### PR TITLE
ci: warn-only D1 migrations until token scoped

### DIFF
--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -88,11 +88,24 @@ jobs:
         run: DEPLOY_URL=https://resume.rafaracing.com.br npm run build
 
       - name: Apply D1 migrations (chat-log schema)
+        # continue-on-error: the current CLOUDFLARE_API_TOKEN ("Edit Cloudflare
+        # Workers" template) lacks the Account → D1 → Edit scope (API code
+        # 7403), and a missing-scope failure must not block site deploys.
+        # Schema is already applied manually (npm run worker:db:migrate).
+        # TODO(rafael): add D1:Edit to the token in the dashboard, then remove
+        # continue-on-error so future migrations gate the deploy again.
+        id: d1-migrations
+        continue-on-error: true
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           wranglerVersion: ${{ env.WRANGLER_VERSION }}
           command: d1 migrations apply resume-ai-logs --remote -c ${{ env.WRANGLER_CONFIG }}
+
+      - name: Warn if D1 migrations were skipped
+        if: steps.d1-migrations.outcome == 'failure'
+        run: |
+          echo "::warning::D1 migrations step failed (most likely the API token lacks the D1 Edit scope — code 7403). Deploy continues; apply pending migrations with 'npm run worker:db:migrate' and add Account → D1 → Edit to CLOUDFLARE_API_TOKEN."
 
       - name: Deploy resume-ai (worker + static assets)
         uses: cloudflare/wrangler-action@v3

--- a/infrastructure/workers/resume-ai/README.md
+++ b/infrastructure/workers/resume-ai/README.md
@@ -118,6 +118,13 @@ Requires `wrangler login` (or `CLOUDFLARE_API_TOKEN`) on the account
 `b76ee39565…`. The custom domain `resume.rafaracing.com.br` is created
 automatically from the route config on first deploy.
 
+D1 schema changes: `npm run worker:db:migrate` (remote) /
+`npm run worker:db:migrate:local` (local dev). The CI token (from the "Edit
+Cloudflare Workers" template) currently lacks the **Account → D1 → Edit**
+scope, so the CI migrations step is warn-only (code 7403) until that scope is
+added to `CLOUDFLARE_API_TOKEN` in the dashboard — after which the
+`continue-on-error` in `worker-deploy.yml` should be removed.
+
 ## Enabling AI Gateway later (currently OFF)
 
 The commented `gatewayOpts` block in `src/index.mjs` is intentionally disabled:


### PR DESCRIPTION
CI token ("Edit Cloudflare Workers" template) lacks **Account → D1 → Edit** → `d1 migrations apply` failed with code 7403 and blocked the entire prod deploy of #193.

- Migration step now `continue-on-error` with a `::warning` annotation on failure
- Schema for #193 is already applied to prod D1 (`npm run worker:db:migrate`)
- README documents the token fix; once D1:Edit is added to `CLOUDFLARE_API_TOKEN`, remove `continue-on-error` to restore the hard gate

**Action for @rafilkmp3:** dashboard → My Profile → API Tokens → edit the CI token → add *Account · D1 · Edit*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1rsqobA2JKHrrUgmtRM7D