### PR TITLE
feat: arm Turnstile on prod chat origin

### DIFF
--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -85,7 +85,13 @@ jobs:
           cache-suffix: 'worker-site'
 
       - name: Build site for prod domain (static assets bundle)
+        # PUBLIC_TURNSTILE_SITEKEY (repo variable) arms the chat widget's
+        # Turnstile challenge; unset/empty keeps it inert. Prod build only —
+        # preview builds stay keyless (their hostnames aren't on the widget,
+        # and the worker skips enforcement for non-prod origins anyway).
         run: DEPLOY_URL=https://resume.rafaracing.com.br npm run build
+        env:
+          PUBLIC_TURNSTILE_SITEKEY: ${{ vars.PUBLIC_TURNSTILE_SITEKEY }}
 
       - name: Apply D1 migrations (chat-log schema)
         # continue-on-error: the current CLOUDFLARE_API_TOKEN ("Edit Cloudflare

--- a/app/components/ChatHero.astro
+++ b/app/components/ChatHero.astro
@@ -85,8 +85,10 @@ const promptCards = chatCards.cards.map((card) => card.q);
         </svg>
       </button>
     </form>
-    <!-- Invisible Turnstile mount (only used when PUBLIC_TURNSTILE_SITEKEY is set) -->
-    <div id="chat-turnstile" aria-hidden="true"></div>
+    <!-- Turnstile mount (only used when PUBLIC_TURNSTILE_SITEKEY is set).
+         Managed mode usually passes invisibly, but can render an interactive
+         challenge here for high-risk visitors — must stay accessible. -->
+    <div id="chat-turnstile"></div>
 
     <!-- Secondary actions -->
     <div class="ch-actions">
@@ -870,6 +872,7 @@ const promptCards = chatCards.cards.map((card) => card.q);
   // its TURNSTILE_SECRET is set — flip both to enable, either alone is inert).
   const TURNSTILE_SITEKEY = import.meta.env.PUBLIC_TURNSTILE_SITEKEY || '';
   let turnstileWidgetId = null;
+  let turnstileExecuted = false;
   function initTurnstile() {
     if (!TURNSTILE_SITEKEY) return;
     const s = document.createElement('script');
@@ -877,9 +880,12 @@ const promptCards = chatCards.cards.map((card) => card.q);
     s.async = true;
     s.onload = function () {
       try {
+        // Invisibility comes from the widget's dashboard mode (Invisible);
+        // execution:'execute' defers the challenge until each send asks for
+        // a token instead of running it once at page load (tokens expire).
         turnstileWidgetId = window.turnstile.render('#chat-turnstile', {
           sitekey: TURNSTILE_SITEKEY,
-          size: 'invisible',
+          execution: 'execute',
         });
       } catch (_e) {
         /* widget render failed — sends proceed tokenless; server decides */
@@ -894,9 +900,13 @@ const promptCards = chatCards.cards.map((card) => card.q);
         return;
       }
       const timer = setTimeout(function () {
-        resolve(null); // challenge hung — send tokenless rather than freeze the chat
-      }, 4000);
+        resolve(null); // challenge hung/unsolved — send tokenless rather than freeze the chat
+      }, 12000); // generous: Managed mode may show an interactive challenge needing a human click
       try {
+        // Tokens are single-use: after the first execute the widget must be
+        // reset before it can issue another.
+        if (turnstileExecuted) window.turnstile.reset(turnstileWidgetId);
+        turnstileExecuted = true;
         window.turnstile.execute(turnstileWidgetId, {
           callback: function (token) {
             clearTimeout(timer);

--- a/infrastructure/workers/resume-ai/src/guards.mjs
+++ b/infrastructure/workers/resume-ai/src/guards.mjs
@@ -1,10 +1,16 @@
 // Request validation, CORS origin resolution, cache-key helpers.
 // Pure module — no Worker APIs, node-testable.
 
+// Turnstile is enforced ONLY for this origin: preview/localhost/LAN origins
+// can never obtain tokens (their hostnames aren't registered on the widget),
+// and bot floods target prod — the other origins keep rate-limit + budget
+// guards but skip the token check.
+export const PROD_ORIGIN = 'https://resume.rafaracing.com.br';
+
 const ALLOWED_ORIGINS = [
   // Primary prod — the site is served from this same origin (Workers Static
   // Assets), so its chat POSTs are same-origin and MUST be allowed.
-  'https://resume.rafaracing.com.br',
+  PROD_ORIGIN,
   // Legacy origins kept allowed during the migration (they 301-redirect to the
   // domain above; harmless to keep on the list, avoids any transition breakage).
   'https://rafilkmp3.github.io',

--- a/infrastructure/workers/resume-ai/src/index.mjs
+++ b/infrastructure/workers/resume-ai/src/index.mjs
@@ -14,6 +14,7 @@ import {
   resolveCorsOrigin,
   normalizeQuestion,
   hashString,
+  PROD_ORIGIN,
 } from './guards.mjs';
 import { aiRunViaGateway, extractAiText, postProcess, detectPromptLeak } from './ai.mjs';
 import { cacheKey as buildCacheKey } from './cache-version.mjs';
@@ -223,17 +224,24 @@ async function handleChat(request, env, ctx, corsOrigin) {
   }
 
   // Turnstile gate — env-gated like AI_GATEWAY_ID: no TURNSTILE_SECRET, no
-  // check (zero-risk toggle). Runs only in front of real AI spend; the
-  // verification service failing open is deliberate (see d1-log.mjs).
+  // check (zero-risk toggle). Enforced ONLY for the prod origin: preview/
+  // localhost/LAN origins can't obtain tokens (hostnames not on the widget)
+  // and would be bricked by enforcement — they keep rate-limit + budget
+  // guards. Runs only in front of real AI spend; the verification service
+  // failing open is deliberate (see d1-log.mjs).
   let turnstile = 'off';
   if (env.TURNSTILE_SECRET) {
-    turnstile = await verifyTurnstile(env.TURNSTILE_SECRET, turnstileToken, ip);
-    if (turnstile === 'fail') {
-      return jsonResponse(
-        403,
-        { error: 'Bot check failed — please reload the page and try again.', code: 'turnstile' },
-        corsOrigin,
-      );
+    if (corsOrigin === PROD_ORIGIN) {
+      turnstile = await verifyTurnstile(env.TURNSTILE_SECRET, turnstileToken, ip);
+      if (turnstile === 'fail') {
+        return jsonResponse(
+          403,
+          { error: 'Bot check failed — please reload the page and try again.', code: 'turnstile' },
+          corsOrigin,
+        );
+      }
+    } else {
+      turnstile = 'skip-origin';
     }
   }
 


### PR DESCRIPTION
Turns the (previously inert) Turnstile gate ON for the production chat.

## Setup done outside code
- Turnstile widget **resume-ai-chat** created in the dashboard: **Managed mode** (Rafael's pick — usually invisible, interactive challenge for high-risk visitors), pre-clearance enabled (Interactive/high), hostname `rafaracing.com.br` (covers subdomains)
- Repo variable `PUBLIC_TURNSTILE_SITEKEY` set (public sitekey)
- Worker secret `TURNSTILE_SECRET`: set by @rafilkmp3 via `wrangler secret put`

## Code
- **Origin-scoped enforcement**: token verification only for `https://resume.rafaracing.com.br`. Netlify previews / localhost / LAN can't obtain tokens (hostnames not registered on the widget) — enforcing there would brick their chat; they keep rate-limit + budget guards and log `turnstile=skip-origin`
- **Client render fix**: `size:'invisible'` isn't a Turnstile render param. Now `execution:'execute'` + `turnstile.reset()` before each execute (tokens are single-use); mount div accessible (Managed mode can render an interactive challenge there), token wait 12s to leave room for a human click
- Prod build step injects `PUBLIC_TURNSTILE_SITEKEY` from the repo variable; preview builds stay keyless

## Verified with Cloudflare official test keys (local wrangler dev)
- pass-secret + dummy token → real reply, D1 row `turnstile=pass`
- fail-secret + token → **403 `code:turnstile`**
- secret set + missing token → **403**
- no secret → gate off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1rsqobA2JKHrrUgmtRM7D