### PR TITLE
feat: add RFC 9116 security.txt

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: https://github.com/rafilkmp3/resume-as-code/security/advisories/new
+Contact: https://www.linkedin.com/in/rafaelsathler
+Expires: 2027-07-29T00:00:00.000Z
+Preferred-Languages: en, pt
+Canonical: https://resume.rafaracing.com.br/.well-known/security.txt
+Policy: https://github.com/rafilkmp3/resume-as-code/security/policy


### PR DESCRIPTION
Serves `/.well-known/security.txt` (RFC 9116) as a static asset — versioned in-repo instead of Cloudflare's dashboard zone generator (dashboard card stays "undefined"; the file wins either way since the Worker serves the path directly).

- Contact: GitHub security advisories + LinkedIn
- Expires: 2027-07-29 (annual renewal — calendar it)
- Canonical: https://resume.rafaracing.com.br/.well-known/security.txt

Part of the zone-hardening sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1rsqobA2JKHrrUgmtRM7D