### PR TITLE
ci: deploy worker on public/ asset changes

### DIFF
--- a/.github/workflows/worker-deploy.yml
+++ b/.github/workflows/worker-deploy.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'infrastructure/workers/resume-ai/**'
       - 'app/**'
+      - 'public/**'
       - 'astro.config.mjs'
       - 'tailwind.config.mjs'
       - 'package.json'
@@ -17,6 +18,7 @@ on:
     paths:
       - 'infrastructure/workers/resume-ai/**'
       - 'app/**'
+      - 'public/**'
       - 'astro.config.mjs'
       - 'tailwind.config.mjs'
       - 'package.json'


### PR DESCRIPTION
public/ assets ship inside the Worker static-assets bundle, but worker-deploy.yml's path filters missed the directory — #196's security.txt never triggered a deploy (caught during live verify; deployed manually via workflow_dispatch meanwhile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1rsqobA2JKHrrUgmtRM7D