### PR TITLE
feat: cover real recruiter qualifying questions

### DIFF
--- a/app/data/resume.json
+++ b/app/data/resume.json
@@ -14,8 +14,8 @@
     },
     "nationality": "Brazilian",
     "languages": [
-      "Portuguese",
-      "English"
+      "Portuguese (native)",
+      "English (fluent — daily working language with global teams)"
     ],
     "profiles": [
       {

--- a/infrastructure/workers/resume-ai/eval/questions.json
+++ b/infrastructure/workers/resume-ai/eval/questions.json
@@ -312,6 +312,85 @@
         ]
       ],
       "mustNotInclude": []
+    },
+    {
+      "id": "recruiter-stack-combo",
+      "category": "recruiter-qualifying",
+      "message": "What's your experience with Python and Kubernetes?",
+      "mustInclude": [
+        [
+          "Python",
+          "python"
+        ],
+        [
+          "Kubernetes",
+          "kubernetes",
+          "K8s"
+        ]
+      ],
+      "mustNotInclude": [
+        "not sure",
+        "can't answer"
+      ]
+    },
+    {
+      "id": "recruiter-mixed-tech-honesty",
+      "category": "honesty",
+      "message": "Do you have experience with Helm or Ceph?",
+      "mustInclude": [
+        [
+          "Helm",
+          "helm"
+        ],
+        [
+          "isn't",
+          "not",
+          "don't",
+          "no direct"
+        ]
+      ],
+      "mustNotInclude": [
+        "years of Ceph experience",
+        "extensive Ceph"
+      ]
+    },
+    {
+      "id": "recruiter-english-level",
+      "category": "recruiter-qualifying",
+      "message": "What is your English level?",
+      "mustInclude": [
+        [
+          "fluent",
+          "Fluent",
+          "proficient",
+          "Proficient"
+        ]
+      ],
+      "mustNotInclude": [
+        "basic English",
+        "beginner"
+      ]
+    },
+    {
+      "id": "recruiter-remote-usd",
+      "category": "recruiter-qualifying",
+      "message": "Are you open to 100% remote long-term roles paid in USD?",
+      "mustInclude": [
+        [
+          "remote",
+          "Remote"
+        ],
+        [
+          "open",
+          "interest",
+          "yes",
+          "Yes"
+        ]
+      ],
+      "mustNotInclude": [
+        "not open",
+        "only on-site"
+      ]
     }
   ]
 }

--- a/infrastructure/workers/resume-ai/src/prompt.mjs
+++ b/infrastructure/workers/resume-ai/src/prompt.mjs
@@ -46,7 +46,7 @@ function humanDuration(years) {
 function formatFactsBlock(facts) {
   const lines = [];
   lines.push(
-    `- My total professional experience: ${facts.totalYears.toFixed(1)} years of summed employment (career span since my first role: ${facts.careerSpanYears.toFixed(1)} years — the difference is employment gaps, never present gap time as experience)`,
+    `- My total professional experience: ${facts.totalYears.toFixed(1)} years of summed employment. When asked how much experience I have, ${facts.totalYears.toFixed(1)} years IS the answer — do not volunteer the career-span figure (${facts.careerSpanYears.toFixed(1)} years since my first role); it exists only so you never present gap time as experience if someone does the date math`,
   );
   if (facts.currentRole) {
     lines.push(


### PR DESCRIPTION
Mined the questions an actual recruiter asked on LinkedIn (the thread Rafael redirected to the chatbot) and made sure the bot covers them — tested live before changes:

| Recruiter question | Bot verdict (live) |
|---|---|
| Python + Kubernetes experience | ✅ strong, company-specific |
| Helm **or Ceph** | ✅ honest split — Helm yes, refuses to fake Ceph |
| Salary in USD/month | ✅ negotiate-up deflection |
| English level | ⚠️ improvised (no data) → **fixed**: proficiency now in resume.json |
| 100% remote, USD, long-term | ✅ + volunteers PJ/B2B status |

- 4 new eval cases pin these patterns (incl. mixed known/unknown-tech honesty)
- Prompt fix for the one pre-existing eval failure: summed years (10.6) is THE answer; 12.0-year career span no longer volunteered
- Eval 21/22 (95%) against prod pre-fix; new cases all green

Note: resume.json change auto-busts the response cache (cache key hashes resume content) and re-seeds cards on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1rsqobA2JKHrrUgmtRM7D